### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/denehoffman/laddu/compare/v0.1.8...v0.1.9) - 2024-11-19
+
+### Added
+
+- add no-op implementations for adding 0 to add-able types
+- update type hints with __ropts__ and add magic methods to easily pickle `Status`
+
+### Other
+
+- remove unused references
+- *(python)* document `as_dict`
+
 ## [0.1.8](https://github.com/denehoffman/laddu/compare/v0.1.7...v0.1.8) - 2024-11-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"


### PR DESCRIPTION
## 🤖 New release
* `laddu`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9](https://github.com/denehoffman/laddu/compare/v0.1.8...v0.1.9) - 2024-11-19

### Added

- add no-op implementations for adding 0 to add-able types
- update type hints with __ropts__ and add magic methods to easily pickle `Status`

### Other

- remove unused references
- *(python)* document `as_dict`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).