### PR TITLE
chore: release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/denehoffman/laddu/compare/v0.1.9...v0.1.10) - 2024-11-20
+
+### Added
+
+- switch API for acceptance correction to not process genmc till projection
+- change the way NLLs are constructed to allow the user to specify a generated dataset
+
+### Fixed
+
+- change `NLL` to always use len(accmc) for `n_mc`
+
+### Other
+
+- use pyproject.toml for doc dependencies
+- add copy button to code
+- update tutorial page
+- add under construction notes
+- finish unbinned tutorial
+- fix doctests and update example_1 results
+- switch argument ordering in `Manager.load`
+- reorganize main page and include tutorials
+- *(docs)* fix doctest with missing parameter
+
 ## [0.1.9](https://github.com/denehoffman/laddu/compare/v0.1.8...v0.1.9) - 2024-11-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"


### PR DESCRIPTION
## 🤖 New release
* `laddu`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.10](https://github.com/denehoffman/laddu/compare/v0.1.9...v0.1.10) - 2024-11-20

### Added

- switch API for acceptance correction to not process genmc till projection
- change the way NLLs are constructed to allow the user to specify a generated dataset

### Fixed

- change `NLL` to always use len(accmc) for `n_mc`

### Other

- use pyproject.toml for doc dependencies
- add copy button to code
- update tutorial page
- add under construction notes
- finish unbinned tutorial
- fix doctests and update example_1 results
- switch argument ordering in `Manager.load`
- reorganize main page and include tutorials
- *(docs)* fix doctest with missing parameter
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).