### PR TITLE
chore: release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/denehoffman/laddu/compare/v0.1.10...v0.1.11) - 2024-11-29
+
+### Fixed
+
+- major bug/typo in boost method and tests to check for it
+
 ## [0.1.10](https://github.com/denehoffman/laddu/compare/v0.1.9...v0.1.10) - 2024-11-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"


### PR DESCRIPTION
## 🤖 New release
* `laddu`: 0.1.10 -> 0.1.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.11](https://github.com/denehoffman/laddu/compare/v0.1.10...v0.1.11) - 2024-11-29

### Fixed

- major bug/typo in boost method and tests to check for it
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).