### PR TITLE
chore: release v0.1.12

### DIFF
--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -117,9 +117,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64
-          - runner: macos-14
+          - runner: macos-latest
             target: aarch64
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/denehoffman/laddu/compare/v0.1.11...v0.1.12) - 2024-12-04
+
+### Added
+
+- add basic implementation to read directly from ROOT files
+- *(bench)* updated benchmark to run over available parallelism
+
+### Fixed
+
+- correct parallelism to allow for proper codspeed benchmarking
+- minor fixes for building without rayon/pyo3
+
+### Other
+
+- Merge pull request [#23](https://github.com/denehoffman/laddu/pull/23) from denehoffman/reading-root
+- get rid of `from_momentum` method and replace with methods coming from 3-vectors
+- change order of four-vector components and modify operation of `boost`
+- bump dependencies
+
 ## [0.1.11](https://github.com/denehoffman/laddu/compare/v0.1.10...v0.1.11) - 2024-11-29
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"


### PR DESCRIPTION
## 🤖 New release
* `laddu`: 0.1.11 -> 0.1.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.12](https://github.com/denehoffman/laddu/compare/v0.1.11...v0.1.12) - 2024-12-04

### Added

- add basic implementation to read directly from ROOT files
- *(bench)* updated benchmark to run over available parallelism

### Fixed

- correct parallelism to allow for proper codspeed benchmarking
- minor fixes for building without rayon/pyo3

### Other

- Merge pull request [#23](https://github.com/denehoffman/laddu/pull/23) from denehoffman/reading-root
- get rid of `from_momentum` method and replace with methods coming from 3-vectors
- change order of four-vector components and modify operation of `boost`
- bump dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).