### PR TITLE
chore: release v0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/denehoffman/laddu/compare/v0.1.13...v0.1.14) - 2024-12-06
+
+### Added
+
+- add intermediate `Model` and serialization updates
+- add perf commands to justfile
+
 ## [0.1.13](https://github.com/denehoffman/laddu/compare/v0.1.12...v0.1.13) - 2024-12-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"


### PR DESCRIPTION
## 🤖 New release
* `laddu`: 0.1.13 -> 0.1.14

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.14](https://github.com/denehoffman/laddu/compare/v0.1.13...v0.1.14) - 2024-12-06

### Added

- add intermediate `Model` and serialization updates
- add perf commands to justfile
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).