### PR TITLE
Parallelism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ pyo3 = { version = "0.23.3", optional = true, features = [
   "abi3-py37",
 ] }
 numpy = { version = "0.23.0", optional = true, features = ["nalgebra"] }
-ganesh = "0.15.2"
+ganesh = "0.16.0"
 thiserror = "2.0.3"
 shellexpand = "3.1.0"
 accurate = "0.4.1"
@@ -45,13 +45,13 @@ typetag = "0.2.18"
 serde-pickle = "1.2.0"
 bincode = "1.3.3"
 fastrand = "2.3.0"
+num_cpus = { version = "1.16.0", optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"
 criterion = { version = "2.7.2", package = "codspeed-criterion-compat", features = [
   "html_reports",
 ] }
-num_cpus = "1.16.0"
 
 [[bench]]
 name = "kmatrix_benchmark"
@@ -66,9 +66,10 @@ default = ["rayon", "python"]
 extension-module = ["pyo3/extension-module"]
 rayon = ["dep:rayon"]
 f32 = ["ganesh/f32"]
-python = ["pyo3", "numpy", "extension-module"]
+python = ["pyo3", "numpy", "extension-module", "num_cpus"]
 pyo3 = ["dep:pyo3"]
 numpy = ["dep:numpy"]
+num_cpus = ["dep:num_cpus"]
 
 [profile.release]
 lto = true

--- a/python/laddu/amplitudes/__init__.pyi
+++ b/python/laddu/amplitudes/__init__.pyi
@@ -53,10 +53,14 @@ class Evaluator:
     def deactivate_all(self) -> None: ...
     def isolate(self, name: str | list[str]) -> None: ...
     def evaluate(
-        self, parameters: list[float] | npt.NDArray[np.float64]
+        self,
+        parameters: list[float] | npt.NDArray[np.float64],
+        threads: int | None = None,
     ) -> npt.NDArray[np.complex128]: ...
     def evaluate_gradient(
-        self, parameters: list[float] | npt.NDArray[np.float64]
+        self,
+        parameters: list[float] | npt.NDArray[np.float64],
+        threads: int | None = None,
     ) -> npt.NDArray[np.complex128]: ...
 
 __all__ = [

--- a/python/laddu/likelihoods/__init__.pyi
+++ b/python/laddu/likelihoods/__init__.pyi
@@ -46,7 +46,11 @@ class LikelihoodManager:
 
 class LikelihoodEvaluator:
     parameters: list[str]
-    def evaluate(self, parameters: list[float] | npt.NDArray[np.float64]) -> float: ...
+    def evaluate(
+        self,
+        parameters: list[float] | npt.NDArray[np.float64],
+        threads: int | None = None,
+    ) -> float: ...
     def minimize(
         self,
         p0: list[float] | npt.NDArray[np.float64],
@@ -86,12 +90,17 @@ class NLL:
     def deactivate(self, name: str | list[str]) -> None: ...
     def deactivate_all(self) -> None: ...
     def isolate(self, name: str | list[str]) -> None: ...
-    def evaluate(self, parameters: list[float] | npt.NDArray[np.float64]) -> float: ...
+    def evaluate(
+        self,
+        parameters: list[float] | npt.NDArray[np.float64],
+        threads: int | None = None,
+    ) -> float: ...
     def project(
         self,
         parameters: list[float] | npt.NDArray[np.float64],
         *,
         mc_evaluator: Evaluator | None = None,
+        threads: int | None = None,
     ) -> npt.NDArray[np.float64]: ...
     def project_with(
         self,
@@ -99,6 +108,7 @@ class NLL:
         name: str | list[str],
         *,
         mc_evaluator: Evaluator | None = None,
+        threads: int | None = None,
     ) -> npt.NDArray[np.float64]: ...
     def minimize(
         self,

--- a/python/laddu/likelihoods/__init__.pyi
+++ b/python/laddu/likelihoods/__init__.pyi
@@ -51,6 +51,11 @@ class LikelihoodEvaluator:
         parameters: list[float] | npt.NDArray[np.float64],
         threads: int | None = None,
     ) -> float: ...
+    def evaluate_gradient(
+        self,
+        parameters: list[float] | npt.NDArray[np.float64],
+        threads: int | None = None,
+    ) -> npt.NDArray[np.float64]: ...
     def minimize(
         self,
         p0: list[float] | npt.NDArray[np.float64],
@@ -95,6 +100,11 @@ class NLL:
         parameters: list[float] | npt.NDArray[np.float64],
         threads: int | None = None,
     ) -> float: ...
+    def evaluate_gradient(
+        self,
+        parameters: list[float] | npt.NDArray[np.float64],
+        threads: int | None = None,
+    ) -> npt.NDArray[np.float64]: ...
     def project(
         self,
         parameters: list[float] | npt.NDArray[np.float64],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,9 +403,10 @@ impl From<LadduError> for PyErr {
             LadduError::ParquetError(_)
             | LadduError::ArrowError(_)
             | LadduError::IOError(_)
-            | LadduError::ThreadPoolError(_)
             | LadduError::PickleError(_) => PyIOError::new_err(err_string),
             LadduError::Custom(_) => PyException::new_err(err_string),
+            #[cfg(feature = "rayon")]
+            LadduError::ThreadPoolError(_) => PyException::new_err(err_string),
         }
     }
 }

--- a/src/likelihoods.rs
+++ b/src/likelihoods.rs
@@ -465,7 +465,6 @@ impl LikelihoodTerm for NLL {
     /// stored by the [`Evaluator`] with the given values for free parameters. This method takes the
     /// real part of the given expression (discarding the imaginary part entirely, which
     /// does not matter if expressions are coherent sums wrapped in [`Expression::norm_sqr`]).
-    /// ```
     #[cfg(not(feature = "rayon"))]
     fn evaluate_gradient(&self, parameters: &[Float]) -> DVector<Float> {
         let data_resources = self.data_evaluator.resources.read();
@@ -852,6 +851,7 @@ pub struct MCMCOptions {
     threads: usize,
 }
 
+/// A set of options that are used when Markov Chain Monte Carlo samplings are performed.
 #[cfg(not(feature = "rayon"))]
 pub struct MCMCOptions {
     algorithm: Box<dyn MCMCAlgorithm<(), LadduError>>,

--- a/src/likelihoods.rs
+++ b/src/likelihoods.rs
@@ -28,8 +28,7 @@ use num::Complex;
 
 use parking_lot::RwLock;
 #[cfg(feature = "rayon")]
-use rayon::prelude::*;
-use rayon::{ThreadPool, ThreadPoolBuilder};
+use rayon::{prelude::*, ThreadPool, ThreadPoolBuilder};
 
 /// A trait which describes a term that can be used like a likelihood (more correctly, a negative
 /// log-likelihood) in a minimization.
@@ -606,8 +605,9 @@ impl Function<(), LadduError> for NLL {
     }
 }
 
-#[cfg(feature = "rayon")]
 pub(crate) struct LogLikelihood<'a>(&'a NLL);
+
+#[cfg(feature = "rayon")]
 impl<'a> Function<ThreadPool, LadduError> for LogLikelihood<'a> {
     fn evaluate(
         &self,
@@ -663,8 +663,10 @@ impl Default for MinimizerOptions {
             algorithm: Box::new(LBFGSB::default()),
             observers: Default::default(),
             max_steps: 4000,
-            #[cfg(feature = "rayon")]
+            #[cfg(all(feature = "rayon", feature = "num_cpus"))]
             threads: num_cpus::get(),
+            #[cfg(all(feature = "rayon", not(feature = "num_cpus")))]
+            threads: 0,
             #[cfg(not(feature = "rayon"))]
             threads: 1,
         }
@@ -863,8 +865,10 @@ impl MCMCOptions {
         Self {
             algorithm: Box::new(ESS::new(moves, rng).with_n_adaptive(100)),
             observers: Default::default(),
-            #[cfg(feature = "rayon")]
+            #[cfg(all(feature = "rayon", feature = "num_cpus"))]
             threads: num_cpus::get(),
+            #[cfg(all(feature = "rayon", not(feature = "num_cpus")))]
+            threads: 0,
             #[cfg(not(feature = "rayon"))]
             threads: 1,
         }
@@ -874,8 +878,10 @@ impl MCMCOptions {
         Self {
             algorithm: Box::new(AIES::new(moves, rng)),
             observers: Default::default(),
-            #[cfg(feature = "rayon")]
+            #[cfg(all(feature = "rayon", feature = "num_cpus"))]
             threads: num_cpus::get(),
+            #[cfg(all(feature = "rayon", not(feature = "num_cpus")))]
+            threads: 0,
             #[cfg(not(feature = "rayon"))]
             threads: 1,
         }

--- a/src/likelihoods.rs
+++ b/src/likelihoods.rs
@@ -1316,7 +1316,9 @@ impl LikelihoodEvaluator {
         Ok(self.likelihood_expression.evaluate(&likelihood_values))
     }
 
-    fn evaluate_gradient(&self, parameters: &[Float]) -> Result<DVector<Float>, LadduError> {
+    /// Evaluate the gradient of the stored [`LikelihoodExpression`] over the events in the [`Dataset`]
+    /// stored by the [`LikelihoodEvaluator`] with the given values for free parameters.
+    pub fn evaluate_gradient(&self, parameters: &[Float]) -> Result<DVector<Float>, LadduError> {
         let mut param_buffers: Vec<Vec<Float>> = self
             .likelihood_manager
             .param_counts

--- a/src/python.rs
+++ b/src/python.rs
@@ -3,6 +3,7 @@ use pyo3::{
     prelude::*,
     types::{PyTuple, PyTupleMethods},
 };
+use rayon::ThreadPool;
 
 #[pymodule]
 #[allow(non_snake_case, clippy::upper_case_acronyms)]
@@ -19,6 +20,7 @@ pub(crate) mod laddu {
     use crate::utils::variables::Variable;
     use crate::utils::vectors::{FourMomentum, FourVector, ThreeMomentum, ThreeVector};
     use crate::Float;
+    use crate::LadduError;
     use bincode::{deserialize, serialize};
     use fastrand::Rng;
     use ganesh::algorithms::lbfgsb::{LBFGSBFTerminator, LBFGSBGTerminator};
@@ -36,6 +38,7 @@ pub(crate) mod laddu {
     use pyo3::exceptions::{PyIndexError, PyTypeError, PyValueError};
     use pyo3::types::PyBytes;
     use pyo3::types::{PyDict, PyList};
+    use rayon::ThreadPoolBuilder;
 
     #[pyfunction]
     fn version() -> String {
@@ -2190,18 +2193,29 @@ pub(crate) mod laddu {
         /// ----------
         /// parameters : list of float
         ///     The values to use for the free parameters
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         /// Returns
         /// -------
         /// result : array_like
         ///     A ``numpy`` array of complex values for each Event in the Dataset
         ///
+        #[pyo3(signature = (parameters, *, threads=None))]
         fn evaluate<'py>(
             &self,
             py: Python<'py>,
             parameters: Vec<Float>,
-        ) -> Bound<'py, PyArray1<Complex<Float>>> {
-            PyArray1::from_slice(py, &self.0.evaluate(&parameters))
+            threads: Option<usize>,
+        ) -> PyResult<Bound<'py, PyArray1<Complex<Float>>>> {
+            Ok(PyArray1::from_slice(
+                py,
+                &ThreadPoolBuilder::new()
+                    .num_threads(threads.unwrap_or_else(num_cpus::get))
+                    .build()
+                    .map_err(LadduError::from)?
+                    .install(|| self.0.evaluate(&parameters)),
+            ))
         }
         /// Evaluate the gradient of the stored Expression over the stored Dataset
         ///
@@ -2209,27 +2223,38 @@ pub(crate) mod laddu {
         /// ----------
         /// parameters : list of float
         ///     The values to use for the free parameters
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         /// Returns
         /// -------
         /// result : array_like
         ///     A ``numpy`` 2D array of complex values for each Event in the Dataset
         ///
+        #[pyo3(signature = (parameters, *, threads=None))]
         fn evaluate_gradient<'py>(
             &self,
             py: Python<'py>,
             parameters: Vec<Float>,
-        ) -> Bound<'py, PyArray2<Complex<Float>>> {
-            PyArray2::from_vec2(
+            threads: Option<usize>,
+        ) -> PyResult<Bound<'py, PyArray2<Complex<Float>>>> {
+            Ok(PyArray2::from_vec2(
                 py,
-                &self
-                    .0
-                    .evaluate_gradient(&parameters)
-                    .iter()
-                    .map(|grad| grad.data.as_vec().to_vec())
-                    .collect::<Vec<Vec<Complex<Float>>>>(),
+                &ThreadPoolBuilder::new()
+                    .num_threads(threads.unwrap_or_else(num_cpus::get))
+                    .build()
+                    .map_err(LadduError::from)?
+                    .install(|| {
+                        self.0
+                            .evaluate_gradient(&parameters)
+                            .iter()
+                            .map(|grad| grad.data.as_vec().to_vec())
+                            .collect::<Vec<Vec<Complex<Float>>>>()
+                    }),
             )
-            .expect("Gradients do not have the same length (please make an issue report on GitHub)")
+            .expect(
+                "Gradients do not have the same length (please make an issue report on GitHub)",
+            ))
         }
     }
 
@@ -2296,6 +2321,10 @@ pub(crate) mod laddu {
             let nelder_mead_x_terminator = kwargs
                 .get_extract::<String>("nelder_mead_x_terminator")?
                 .unwrap_or("singer".into());
+            let threads = kwargs
+                .get_extract::<usize>("threads")
+                .unwrap_or(None)
+                .unwrap_or_else(num_cpus::get);
             let mut observers: Vec<Arc<RwLock<PyObserver>>> = Vec::default();
             if let Ok(Some(observer_arg)) = kwargs.get_item("observers") {
                 if let Ok(observer_list) = observer_arg.downcast::<PyList>() {
@@ -2385,6 +2414,7 @@ pub(crate) mod laddu {
                     )))
                 }
             }
+            options = options.with_threads(threads);
         }
         if debug {
             options = options.debug();
@@ -2471,7 +2501,11 @@ pub(crate) mod laddu {
             if aies_moves.is_empty() {
                 aies_moves = default_aies_moves.to_vec();
             }
-            let mut observers: Vec<Arc<RwLock<dyn ganesh::mcmc::MCMCObserver<()>>>> =
+            let threads = kwargs
+                .get_extract::<usize>("threads")
+                .unwrap_or(None)
+                .unwrap_or_else(num_cpus::get);
+            let mut observers: Vec<Arc<RwLock<dyn ganesh::mcmc::MCMCObserver<ThreadPool>>>> =
                 Vec::default();
             if let Ok(Some(observer_arg)) = kwargs.get_item("observers") {
                 if let Ok(observer_list) = observer_arg.downcast::<PyList>() {
@@ -2512,6 +2546,7 @@ pub(crate) mod laddu {
                     )))
                 }
             }
+            options = options.with_threads(threads);
         }
         if debug {
             options = options.debug();
@@ -2687,14 +2722,21 @@ pub(crate) mod laddu {
         /// ----------
         /// parameters : list of float
         ///     The values to use for the free parameters
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         /// Returns
         /// -------
         /// result : float
         ///     The total negative log-likelihood
         ///
-        fn evaluate(&self, parameters: Vec<Float>) -> Float {
-            self.0.evaluate(&parameters)
+        #[pyo3(signature = (parameters, *, threads=None))]
+        fn evaluate(&self, parameters: Vec<Float>, threads: Option<usize>) -> PyResult<Float> {
+            Ok(ThreadPoolBuilder::new()
+                .num_threads(threads.unwrap_or_else(num_cpus::get))
+                .build()
+                .map_err(LadduError::from)?
+                .install(|| self.0.evaluate(&parameters)))
         }
         /// Evaluate the gradient of the negative log-likelihood over the stored Dataset
         ///
@@ -2702,18 +2744,30 @@ pub(crate) mod laddu {
         /// ----------
         /// parameters : list of float
         ///     The values to use for the free parameters
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         /// Returns
         /// -------
         /// result : array_like
         ///     A ``numpy`` array of representing the gradient of the negative log-likelihood over each parameter
         ///
+        #[pyo3(signature = (parameters, *, threads=None))]
         fn evaluate_gradient<'py>(
             &self,
             py: Python<'py>,
             parameters: Vec<Float>,
-        ) -> Bound<'py, PyArray1<Float>> {
-            PyArray1::from_slice(py, self.0.evaluate_gradient(&parameters).as_slice())
+            threads: Option<usize>,
+        ) -> PyResult<Bound<'py, PyArray1<Float>>> {
+            Ok(PyArray1::from_slice(
+                py,
+                ThreadPoolBuilder::new()
+                    .num_threads(threads.unwrap_or_else(num_cpus::get))
+                    .build()
+                    .map_err(LadduError::from)?
+                    .install(|| self.0.evaluate_gradient(&parameters))
+                    .as_slice(),
+            ))
         }
         /// Project the model over the Monte Carlo dataset with the given parameter values
         ///
@@ -2727,25 +2781,34 @@ pub(crate) mod laddu {
         ///     The values to use for the free parameters
         /// mc_evaluator: Evaluator, optional
         ///     Project using the given Evaluator or use the stored ``accmc`` if None
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         /// Returns
         /// -------
         /// result : array_like
         ///     Weights for every Monte Carlo event which represent the fit to data
         ///
-        #[pyo3(signature = (parameters, *, mc_evaluator = None))]
+        #[pyo3(signature = (parameters, *, mc_evaluator = None, threads=None))]
         fn project<'py>(
             &self,
             py: Python<'py>,
             parameters: Vec<Float>,
             mc_evaluator: Option<Evaluator>,
-        ) -> Bound<'py, PyArray1<Float>> {
-            PyArray1::from_slice(
+            threads: Option<usize>,
+        ) -> PyResult<Bound<'py, PyArray1<Float>>> {
+            Ok(PyArray1::from_slice(
                 py,
-                &self
-                    .0
-                    .project(&parameters, mc_evaluator.map(|pyeval| pyeval.0.clone())),
-            )
+                ThreadPoolBuilder::new()
+                    .num_threads(threads.unwrap_or_else(num_cpus::get))
+                    .build()
+                    .map_err(LadduError::from)?
+                    .install(|| {
+                        self.0
+                            .project(&parameters, mc_evaluator.map(|pyeval| pyeval.0.clone()))
+                    })
+                    .as_slice(),
+            ))
         }
 
         /// Project the model over the Monte Carlo dataset with the given parameter values, first
@@ -2764,6 +2827,8 @@ pub(crate) mod laddu {
         ///     Names of Amplitudes to be isolated
         /// mc_evaluator: Evaluator, optional
         ///     Project using the given Evaluator or use the stored ``accmc`` if None
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         /// Returns
         /// -------
@@ -2775,13 +2840,14 @@ pub(crate) mod laddu {
         /// TypeError
         ///     If `arg` is not a str or list of str
         ///
-        #[pyo3(signature = (parameters, arg, *, mc_evaluator = None))]
+        #[pyo3(signature = (parameters, arg, *, mc_evaluator = None, threads=None))]
         fn project_with<'py>(
             &self,
             py: Python<'py>,
             parameters: Vec<Float>,
             arg: &Bound<'_, PyAny>,
             mc_evaluator: Option<Evaluator>,
+            threads: Option<usize>,
         ) -> PyResult<Bound<'py, PyArray1<Float>>> {
             let names = if let Ok(string_arg) = arg.extract::<String>() {
                 vec![string_arg]
@@ -2795,11 +2861,18 @@ pub(crate) mod laddu {
             };
             Ok(PyArray1::from_slice(
                 py,
-                &self.0.project_with(
-                    &parameters,
-                    &names,
-                    mc_evaluator.map(|pyeval| pyeval.0.clone()),
-                ),
+                ThreadPoolBuilder::new()
+                    .num_threads(threads.unwrap_or_else(num_cpus::get))
+                    .build()
+                    .map_err(LadduError::from)?
+                    .install(|| {
+                        self.0.project_with(
+                            &parameters,
+                            &names,
+                            mc_evaluator.map(|pyeval| pyeval.0.clone()),
+                        )
+                    })
+                    .as_slice(),
             ))
         }
 
@@ -2864,6 +2937,8 @@ pub(crate) mod laddu {
         ///     The function terminator used by the Nelder-Mead algorithm
         /// nelder_mead_x_terminator : {'singer', 'diameter', 'rowan', 'higham', 'none'}
         ///     The positional terminator used by the Nelder-Mead algorithm
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         #[pyo3(signature = (p0, *, bounds=None, method="lbfgsb", max_steps=4000, debug=false, verbose=false, **kwargs))]
         #[allow(clippy::too_many_arguments)]
@@ -2891,7 +2966,7 @@ pub(crate) mod laddu {
             let n_parameters = p0.len();
             let options =
                 _parse_minimizer_options(n_parameters, method, max_steps, debug, verbose, kwargs)?;
-            let status = self.0.minimize(&p0, bounds, Some(options));
+            let status = self.0.minimize(&p0, bounds, Some(options))?;
             Ok(Status(status))
         }
         /// Run an MCMC algorithm on the free parameters of the NLL's model
@@ -2923,6 +2998,8 @@ pub(crate) mod laddu {
         ///     ESS adaptive parameter
         /// max_ess_steps : int, default=10000
         ///     The maximum number of slice expansions/contractions performed in the ESS algorithm
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         /// Returns
         /// -------
@@ -3215,14 +3292,21 @@ pub(crate) mod laddu {
         /// ----------
         /// parameters : list of float
         ///     The values to use for the free parameters
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         /// Returns
         /// -------
         /// result : float
         ///     The total negative log-likelihood summed over all terms
         ///
-        fn evaluate(&self, parameters: Vec<Float>) -> Float {
-            self.0.evaluate(&parameters)
+        #[pyo3(signature = (parameters, *, threads=None))]
+        fn evaluate(&self, parameters: Vec<Float>, threads: Option<usize>) -> PyResult<Float> {
+            Ok(ThreadPoolBuilder::new()
+                .num_threads(threads.unwrap_or_else(num_cpus::get))
+                .build()
+                .map_err(LadduError::from)?
+                .install(|| self.0.evaluate(&parameters))?)
         }
         /// Minimize all LikelihoodTerms with respect to the free parameters in the model
         ///
@@ -3285,6 +3369,8 @@ pub(crate) mod laddu {
         ///     The function terminator used by the Nelder-Mead algorithm
         /// nelder_mead_x_terminator : {'singer', 'diameter', 'rowan', 'higham', 'none'}
         ///     The positional terminator used by the Nelder-Mead algorithm
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         #[pyo3(signature = (p0, *, bounds=None, method="lbfgsb", max_steps=4000, debug=false, verbose=false, **kwargs))]
         #[allow(clippy::too_many_arguments)]
@@ -3312,7 +3398,7 @@ pub(crate) mod laddu {
             let n_parameters = p0.len();
             let options =
                 _parse_minimizer_options(n_parameters, method, max_steps, debug, verbose, kwargs)?;
-            let status = self.0.minimize(&p0, bounds, Some(options));
+            let status = self.0.minimize(&p0, bounds, Some(options))?;
             Ok(Status(status))
         }
 
@@ -3345,6 +3431,8 @@ pub(crate) mod laddu {
         ///     ESS adaptive parameter
         /// max_ess_steps : int, default=10000
         ///     The maximum number of slice expansions/contractions performed in the ESS algorithm
+        /// threads : int, optional
+        ///     The number of threads to use (setting this to None will use all available CPUs)
         ///
         /// Returns
         /// -------
@@ -4601,12 +4689,75 @@ impl Observer<()> for crate::python::laddu::PyObserver {
         result
     }
 }
+
+impl Observer<ThreadPool> for crate::python::laddu::PyObserver {
+    fn callback(
+        &mut self,
+        step: usize,
+        status: &mut ganesh::Status,
+        _thread_pool: &mut ThreadPool,
+    ) -> bool {
+        let (new_status, result) = Python::with_gil(|py| {
+            let res = self
+                .0
+                .bind(py)
+                .call_method(
+                    "callback",
+                    (step, crate::python::laddu::Status(status.clone())),
+                    None,
+                )
+                .unwrap();
+            let res_tuple = res.downcast::<PyTuple>().unwrap();
+            let new_status = res_tuple
+                .get_item(0)
+                .unwrap()
+                .extract::<crate::python::laddu::Status>()
+                .unwrap()
+                .0;
+            let result = res_tuple.get_item(1).unwrap().extract::<bool>().unwrap();
+            (new_status, result)
+        });
+        *status = new_status;
+        result
+    }
+}
 impl FromPyObject<'_> for crate::python::laddu::PyObserver {
     fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
         Ok(crate::python::laddu::PyObserver(ob.clone().into()))
     }
 }
 
+impl MCMCObserver<ThreadPool> for crate::python::laddu::PyMCMCObserver {
+    fn callback(
+        &mut self,
+        step: usize,
+        ensemble: &mut ganesh::mcmc::Ensemble,
+        _thread_pool: &mut ThreadPool,
+    ) -> bool {
+        let (new_ensemble, result) = Python::with_gil(|py| {
+            let res = self
+                .0
+                .bind(py)
+                .call_method(
+                    "callback",
+                    (step, crate::python::laddu::Ensemble(ensemble.clone())),
+                    None,
+                )
+                .unwrap();
+            let res_tuple = res.downcast::<PyTuple>().unwrap();
+            let new_status = res_tuple
+                .get_item(0)
+                .unwrap()
+                .extract::<crate::python::laddu::Ensemble>()
+                .unwrap()
+                .0;
+            let result = res_tuple.get_item(1).unwrap().extract::<bool>().unwrap();
+            (new_status, result)
+        });
+        *ensemble = new_ensemble;
+        result
+    }
+}
 impl MCMCObserver<()> for crate::python::laddu::PyMCMCObserver {
     fn callback(
         &mut self,


### PR DESCRIPTION
Improves the parallel API by defining thread pools for each method and a custom `threads` keyword argument to most methods that would use multithreading. This can give users precise control over the number of threads being used on a per-call basis rather than relying on an environment variable like `RAYON_NUM_THREADS`.

I've implemented this in a way that should mostly leave the Rust API unaffected, but the idea is to allow users of Rust to just use their own `ThreadPool` if they want.

Additionally, I exposed gradient evaluators for `NLL` and `LikelihoodExpression` to Python, since these were always available in Rust but not in Python