### PR TITLE
chore: release v0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/denehoffman/laddu/compare/v0.1.15...v0.1.16) - 2025-01-05
+
+### Added
+
+- add gradient evaluation to `NLL` and `LikelihoodExpression` in Python API
+- add 'threads' argument to pretty much everything in Python API
+
+### Fixed
+
+- add better feature guards so all features can technically be used independently
+
+### Other
+
+- add docs to `MCMCOptions` in non-rayon mode and clean up some extra text
+
 ## [0.1.15](https://github.com/denehoffman/laddu/compare/v0.1.14...v0.1.15) - 2024-12-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"


### PR DESCRIPTION
## 🤖 New release
* `laddu`: 0.1.15 -> 0.1.16

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.16](https://github.com/denehoffman/laddu/compare/v0.1.15...v0.1.16) - 2025-01-05

### Added

- add gradient evaluation to `NLL` and `LikelihoodExpression` in Python API
- add 'threads' argument to pretty much everything in Python API

### Fixed

- add better feature guards so all features can technically be used independently

### Other

- add docs to `MCMCOptions` in non-rayon mode and clean up some extra text
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).