### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.2.2", path = "crates/laddu" }
-laddu-core = { version = "0.2.2", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.2.2", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.2.2", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.2.2", path = "crates/laddu-python" }
+laddu = { version = "0.2.3", path = "crates/laddu" }
+laddu-core = { version = "0.2.3", path = "crates/laddu-core" }
+laddu-amplitudes = { version = "0.2.3", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.2.3", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.2.3", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.2...laddu-amplitudes-v0.2.3) - 2025-01-24
+
+### Other
+
+- updated the following local packages: laddu-core

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.2.2"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-core/CHANGELOG.md
+++ b/crates/laddu-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-core-v0.2.2...laddu-core-v0.2.3) - 2025-01-24
+
+### Added
+
+- add `BinnedGuideTerm` under new `experimental` module
+- allow users to add `Dataset`s together to form a new `Dataset`
+
 ## [0.1.17](https://github.com/denehoffman/laddu/compare/v0.1.16...v0.1.17) - 2025-01-14
 
 ### Added

--- a/crates/laddu-core/Cargo.toml
+++ b/crates/laddu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-core"
-version = "0.2.2"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.2...laddu-extensions-v0.2.3) - 2025-01-24
+
+### Added
+
+- add `BinnedGuideTerm` under new `experimental` module

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.2.2"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.2...laddu-python-v0.2.3) - 2025-01-24
+
+### Other
+
+- updated the following local packages: laddu-core

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.2.2"
+version = "0.2.3"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-v0.2.2...laddu-v0.2.3) - 2025-01-24
+
+### Added
+
+- add `BinnedGuideTerm` under new `experimental` module
+- allow users to add `Dataset`s together to form a new `Dataset`

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.2.2"
+version = "0.2.3"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,42 +1,35 @@
 [workspace]
 publish = false
-git_release_enable = false
 git_tag_enable = false
 
 [[package]]
 name = "laddu-core"
 publish = true
-git_release_enable = true
 git_tag_enable = true
 
 [[package]]
 name = "laddu-amplitudes"
 publish = true
-git_release_enable = true
 git_tag_enable = true
 
 [[package]]
 name = "laddu-extensions"
 publish = true
-git_release_enable = true
 git_tag_enable = true
 
 [[package]]
 name = "laddu"
 changelog_include = ["laddu-core", "laddu-amplitudes", "laddu-extensions"]
 publish = true
-git_release_enable = true
 git_tag_enable = true
 
 [[package]]
 name = "laddu-python"
 publish = true
-git_release_enable = true
 git_tag_enable = true
 
 [[package]]
 name = "py-laddu"
 changelog_include = ["laddu-core", "laddu-amplitudes", "laddu-extensions"]
 publish = false
-git_release_enable = false
 git_tag_enable = false


### PR DESCRIPTION
## 🤖 New release
* `laddu`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `laddu-core`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `laddu-extensions`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `py-laddu`: 0.2.2
* `laddu-amplitudes`: 0.2.2 -> 0.2.3
* `laddu-python`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu`
<blockquote>

## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-v0.2.2...laddu-v0.2.3) - 2025-01-24

### Added

- add `BinnedGuideTerm` under new `experimental` module
- allow users to add `Dataset`s together to form a new `Dataset`
</blockquote>

## `laddu-core`
<blockquote>

## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-core-v0.2.2...laddu-core-v0.2.3) - 2025-01-24

### Added

- add `BinnedGuideTerm` under new `experimental` module
- allow users to add `Dataset`s together to form a new `Dataset`
</blockquote>

## `laddu-extensions`
<blockquote>

## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.2...laddu-extensions-v0.2.3) - 2025-01-24

### Added

- add `BinnedGuideTerm` under new `experimental` module
</blockquote>

## `py-laddu`
<blockquote>

## [0.2.2](https://github.com/denehoffman/laddu/releases/tag/py-laddu-v0.2.2) - 2025-01-24

### Fixed

- corrected signature in methods that read from AmpTools trees
- fixed python examples and readme paths
- modify tests and workflows to new structure

### Other

- bump version
- *(py-laddu)* release v0.2.1
- force version bump
- fix python docs to use "extensions" rather than "likelihoods"
- *(py-laddu)* release v0.2.0
- release all crates manually
- release-plz does not like the way I've set up the workspace. I've looked at conda/rattler for some inspiration, but I might need to manually publish each crate once to get the ball rolling
- add rust version to py-laddu
- complete python integration to new py-laddu crate
- major rewrite
</blockquote>

## `laddu-amplitudes`
<blockquote>

## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.2...laddu-amplitudes-v0.2.3) - 2025-01-24

### Other

- updated the following local packages: laddu-core
</blockquote>

## `laddu-python`
<blockquote>

## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.2...laddu-python-v0.2.3) - 2025-01-24

### Other

- updated the following local packages: laddu-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).