### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,10 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.2.3", path = "crates/laddu" }
+laddu = { version = "0.2.4", path = "crates/laddu" }
 laddu-core = { version = "0.2.3", path = "crates/laddu-core" }
 laddu-amplitudes = { version = "0.2.3", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.2.3", path = "crates/laddu-extensions" }
+laddu-extensions = { version = "0.2.4", path = "crates/laddu-extensions" }
 laddu-python = { version = "0.2.3", path = "crates/laddu-python" }
 
 [profile.release]

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.3...laddu-extensions-v0.2.4) - 2025-01-26
+
+### Added
+
+- implement custom gradient for `BinnedGuideTerm`
+- add `project_gradient` and `project_gradient_with` methods to `NLL`
+
+### Other
+
+- fix some docstring links in `laddu-extensions`
+
 ## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.2...laddu-extensions-v0.2.3) - 2025-01-24
 
 ### Added

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.2.3"
+version = "0.2.4"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/denehoffman/laddu/compare/laddu-v0.2.3...laddu-v0.2.4) - 2025-01-26
+
+### Added
+
+- implement custom gradient for `BinnedGuideTerm`
+- add `project_gradient` and `project_gradient_with` methods to `NLL`
+
+### Other
+
+- fix some docstring links in `laddu-extensions`
+
 ## [0.2.3](https://github.com/denehoffman/laddu/compare/laddu-v0.2.2...laddu-v0.2.3) - 2025-01-24
 
 ### Added

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.2.3"
+version = "0.2.4"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `laddu`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `laddu-extensions`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `py-laddu`: 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu`
<blockquote>

## [0.2.4](https://github.com/denehoffman/laddu/compare/laddu-v0.2.3...laddu-v0.2.4) - 2025-01-26

### Added

- implement custom gradient for `BinnedGuideTerm`
- add `project_gradient` and `project_gradient_with` methods to `NLL`

### Other

- fix some docstring links in `laddu-extensions`
</blockquote>

## `laddu-extensions`
<blockquote>

## [0.2.4](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.3...laddu-extensions-v0.2.4) - 2025-01-26

### Added

- implement custom gradient for `BinnedGuideTerm`
- add `project_gradient` and `project_gradient_with` methods to `NLL`

### Other

- fix some docstring links in `laddu-extensions`
</blockquote>

## `py-laddu`
<blockquote>

## [0.2.3](https://github.com/denehoffman/laddu/releases/tag/py-laddu-v0.2.3) - 2025-01-24

### Added

- add `BinnedGuideTerm` under new `experimental` module
- allow users to add `Dataset`s together to form a new `Dataset`

### Fixed

- fixed python examples and readme paths
- modify tests and workflows to new structure

### Other

- manually update py-laddu version
- omit tests and docs in python coverage
- correct path of extensions module
- *(py-laddu)* release v0.2.0
- release all crates manually
- release-plz does not like the way I've set up the workspace. I've looked at conda/rattler for some inspiration, but I might need to manually publish each crate once to get the ball rolling
- add rust version to py-laddu
- complete python integration to new py-laddu crate
- major rewrite
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).