### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.2.5", path = "crates/laddu" }
-laddu-core = { version = "0.2.4", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.2.4", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.2.5", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.2.4", path = "crates/laddu-python" }
+laddu = { version = "0.2.6", path = "crates/laddu" }
+laddu-core = { version = "0.2.5", path = "crates/laddu-core" }
+laddu-amplitudes = { version = "0.2.5", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.2.6", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.2.5", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.4...laddu-amplitudes-v0.2.5) - 2025-01-28
+
+### Other
+
+- updated the following local packages: laddu-core, laddu-python
+
 ## [0.2.4](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.3...laddu-amplitudes-v0.2.4) - 2025-01-27
 
 ### Other

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.2.4"
+version = "0.2.5"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-core/CHANGELOG.md
+++ b/crates/laddu-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-core-v0.2.4...laddu-core-v0.2.5) - 2025-01-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.4](https://github.com/denehoffman/laddu/compare/laddu-core-v0.2.3...laddu-core-v0.2.4) - 2025-01-27
 
 ### Fixed

--- a/crates/laddu-core/Cargo.toml
+++ b/crates/laddu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-core"
-version = "0.2.4"
+version = "0.2.5"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.5...laddu-extensions-v0.2.6) - 2025-01-28
+
+### Added
+
+- bump `ganesh`  to add "skip_hessian" minimization option to skip calculation of Hessian matrix
+
+### Fixed
+
+- use proper ownership in setting algorithm error mode
+- use correct enum in L-BFGS-B error method
+
 ## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.4...laddu-extensions-v0.2.5) - 2025-01-27
 
 ### Other

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.2.5"
+version = "0.2.6"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.4...laddu-python-v0.2.5) - 2025-01-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.4](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.3...laddu-python-v0.2.4) - 2025-01-27
 
 ### Added

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.2.4"
+version = "0.2.5"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-v0.2.5...laddu-v0.2.6) - 2025-01-28
+
+### Added
+
+- bump `ganesh`  to add "skip_hessian" minimization option to skip calculation of Hessian matrix
+
+### Fixed
+
+- use proper ownership in setting algorithm error mode
+- use correct enum in L-BFGS-B error method
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-v0.2.4...laddu-v0.2.5) - 2025-01-27
 
 ### Fixed

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.2.5"
+version = "0.2.6"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/denehoffman/laddu/compare/py-laddu-v0.2.5...py-laddu-v0.2.6) - 2025-01-28
+
+### Added
+
+- bump `ganesh`  to add "skip_hessian" minimization option to skip calculation of Hessian matrix
+
+### Fixed
+
+- use proper ownership in setting algorithm error mode
+- use correct enum in L-BFGS-B error method
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.5](https://github.com/denehoffman/laddu/compare/py-laddu-v0.2.4...py-laddu-v0.2.5) - 2025-01-27
 
 ### Fixed

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `laddu`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `laddu-core`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `laddu-python`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `laddu-extensions`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `py-laddu`: 0.2.5 -> 0.2.6
* `laddu-amplitudes`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu`
<blockquote>

## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-v0.2.5...laddu-v0.2.6) - 2025-01-28

### Added

- bump `ganesh`  to add "skip_hessian" minimization option to skip calculation of Hessian matrix

### Fixed

- use proper ownership in setting algorithm error mode
- use correct enum in L-BFGS-B error method

### Other

- update Cargo.toml dependencies
</blockquote>

## `laddu-core`
<blockquote>

## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-core-v0.2.4...laddu-core-v0.2.5) - 2025-01-28

### Other

- update Cargo.toml dependencies
</blockquote>

## `laddu-python`
<blockquote>

## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.4...laddu-python-v0.2.5) - 2025-01-28

### Other

- update Cargo.toml dependencies
</blockquote>

## `laddu-extensions`
<blockquote>

## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.5...laddu-extensions-v0.2.6) - 2025-01-28

### Added

- bump `ganesh`  to add "skip_hessian" minimization option to skip calculation of Hessian matrix

### Fixed

- use proper ownership in setting algorithm error mode
- use correct enum in L-BFGS-B error method
</blockquote>

## `py-laddu`
<blockquote>

## [0.2.6](https://github.com/denehoffman/laddu/compare/py-laddu-v0.2.5...py-laddu-v0.2.6) - 2025-01-28

### Added

- bump `ganesh`  to add "skip_hessian" minimization option to skip calculation of Hessian matrix

### Fixed

- use proper ownership in setting algorithm error mode
- use correct enum in L-BFGS-B error method

### Other

- update Cargo.toml dependencies
</blockquote>

## `laddu-amplitudes`
<blockquote>

## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.4...laddu-amplitudes-v0.2.5) - 2025-01-28

### Other

- updated the following local packages: laddu-core, laddu-python
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).