### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.2.7", path = "crates/laddu" }
+laddu = { version = "0.3.0", path = "crates/laddu" }
 laddu-core = { version = "0.3.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.2.6", path = "crates/laddu-amplitudes" }
+laddu-amplitudes = { version = "0.3.0", path = "crates/laddu-amplitudes" }
 laddu-extensions = { version = "0.3.0", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.2.6", path = "crates/laddu-python" }
+laddu-python = { version = "0.3.0", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.2.6", path = "crates/laddu" }
-laddu-core = { version = "0.2.5", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.2.5", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.2.6", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.2.5", path = "crates/laddu-python" }
+laddu = { version = "0.2.7", path = "crates/laddu" }
+laddu-core = { version = "0.3.0", path = "crates/laddu-core" }
+laddu-amplitudes = { version = "0.2.6", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.3.0", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.2.6", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.5...laddu-amplitudes-v0.2.6) - 2025-02-21
+## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.5...laddu-amplitudes-v0.3.0) - 2025-02-21
 
 ### Other
 

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.5...laddu-amplitudes-v0.2.6) - 2025-02-21
+
+### Other
+
+- update all documentation to include MPI modules
+- add some clippy lints and clean up some unused imports and redundant code
+
 ## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.4...laddu-amplitudes-v0.2.5) - 2025-01-28
 
 ### Other

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.2.6"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.2.5"
+version = "0.2.6"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-core/CHANGELOG.md
+++ b/crates/laddu-core/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.2.5...laddu-core-v0.3.0) - 2025-02-21
+
+### Added
+
+- switch the MPI implementation to use safe Rust via a RwLock
+- update MPI code to use root-node-agnostic methods
+- first pass implementation of MPI interface
+
+### Fixed
+
+- calling get_world before use_mpi causes errors
+- correct the open method and counts/displs methods
+
+### Other
+
+- *(vectors)* complete tests for vectors module
+- *(vectors)* add more vector test coverage
+- update all documentation to include MPI modules
+- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
+
 ## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-core-v0.2.4...laddu-core-v0.2.5) - 2025-01-28
 
 ### Other

--- a/crates/laddu-core/Cargo.toml
+++ b/crates/laddu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-core"
-version = "0.2.5"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.6...laddu-extensions-v0.3.0) - 2025-02-21
+
+### Added
+
+- update MPI code to use root-node-agnostic methods
+- first pass implementation of MPI interface
+
+### Other
+
+- *(ganesh_ext)* documenting a few missed functions
+- update all documentation to include MPI modules
+- add some clippy lints and clean up some unused imports and redundant code
+- use elided lifetimes
+
 ## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.5...laddu-extensions-v0.2.6) - 2025-01-28
 
 ### Added

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.2.6"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.5...laddu-python-v0.2.6) - 2025-02-21
+
+### Added
+
+- update MPI code to use root-node-agnostic methods
+- first pass implementation of MPI interface
+
+### Fixed
+
+- forgot to update the `laddu-python` `use_mpi` function to have a trigger arg
+- add feature flag to `laddu-python` and update MSRV for `mpisys` compatibility
+
+### Other
+
+- update all documentation to include MPI modules
+- add some clippy lints and clean up some unused imports and redundant code
+- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
+
 ## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.4...laddu-python-v0.2.5) - 2025-01-28
 
 ### Other

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.5...laddu-python-v0.2.6) - 2025-02-21
+## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.5...laddu-python-v0.3.0) - 2025-02-21
 
 ### Added
 

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.2.5"
+version = "0.2.6"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.2.6"
+version = "0.3.0"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/denehoffman/laddu/compare/laddu-v0.2.6...laddu-v0.2.7) - 2025-02-21
+
+### Added
+
+- update MPI code to use root-node-agnostic methods
+- first pass implementation of MPI interface
+- switch the MPI implementation to use safe Rust via a RwLock
+
+### Fixed
+
+- add sentry dependency for which to force the version, not sure what the best fix really is, but this should work for now
+- calling get_world before use_mpi causes errors
+- correct the open method and counts/displs methods
+
+### Other
+
+- update all documentation to include MPI modules
+- add some clippy lints and clean up some unused imports and redundant code
+- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
+- update benchmark to only run on powers of 2 threads
+- *(vectors)* complete tests for vectors module
+- *(vectors)* add more vector test coverage
+- *(ganesh_ext)* documenting a few missed functions
+- use elided lifetimes
+
 ## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-v0.2.5...laddu-v0.2.6) - 2025-01-28
 
 ### Added

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.7](https://github.com/denehoffman/laddu/compare/laddu-v0.2.6...laddu-v0.2.7) - 2025-02-21
+## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-v0.2.6...laddu-v0.3.0) - 2025-02-21
 
 ### Added
 

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.2.7"
+version = "0.3.0"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.2.6"
+version = "0.2.7"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.7](https://github.com/denehoffman/laddu/compare/py-laddu-v0.2.6...py-laddu-v0.2.7) - 2025-02-21
+## [0.3.0](https://github.com/denehoffman/laddu/compare/py-laddu-v0.2.6...py-laddu-v0.3.0) - 2025-02-21
 
 ### Added
 

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/denehoffman/laddu/compare/py-laddu-v0.2.6...py-laddu-v0.2.7) - 2025-02-21
+
+### Added
+
+- make `mpi` a feature in `py-laddu` to allow people to build the python package without it
+- update MPI code to use root-node-agnostic methods
+- first pass implementation of MPI interface
+- switch the MPI implementation to use safe Rust via a RwLock
+
+### Fixed
+
+- add non-MPI failing functions for MPI calls on non-MPI python builds
+- add mpi feature for laddu-python to py-laddu
+- calling get_world before use_mpi causes errors
+- correct the open method and counts/displs methods
+
+### Other
+
+- update all documentation to include MPI modules
+- add mpich to builds
+- *(vectors)* complete tests for vectors module
+- *(vectors)* add more vector test coverage
+- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
+- add some clippy lints and clean up some unused imports and redundant code
+- *(ganesh_ext)* documenting a few missed functions
+- use elided lifetimes
+
 ## [0.2.6](https://github.com/denehoffman/laddu/compare/py-laddu-v0.2.5...py-laddu-v0.2.6) - 2025-01-28
 
 ### Added

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.2.7"
+version = "0.3.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `laddu-amplitudes`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `laddu-core`: 0.2.5 -> 0.3.0 (⚠ API breaking changes)
* `laddu-python`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `laddu-extensions`: 0.2.6 -> 0.3.0 (⚠ API breaking changes)
* `py-laddu`: 0.2.6 -> 0.2.7

### ⚠ `laddu-core` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/inherent_method_missing.ron

Failed in:
  BinnedDataset::len, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:448
  BinnedDataset::is_empty, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:453
  BinnedDataset::bins, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:458
  BinnedDataset::len, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:448
  BinnedDataset::is_empty, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:453
  BinnedDataset::bins, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:458
  Dataset::len, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:124
  Dataset::is_empty, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:129
  Dataset::iter, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:134
  Dataset::par_iter, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:142
  Dataset::weighted_len, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:155
  Dataset::len, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:124
  Dataset::is_empty, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:129
  Dataset::iter, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:134
  Dataset::par_iter, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:142
  Dataset::weighted_len, previously in file /tmp/.tmpcIymIG/laddu-core/src/data.rs:155

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/trait_missing.ron

Failed in:
  trait laddu_core::utils::vectors::FourMomentum, previously in file /tmp/.tmpcIymIG/laddu-core/src/utils/vectors.rs:18
  trait laddu_core::traits::FourMomentum, previously in file /tmp/.tmpcIymIG/laddu-core/src/utils/vectors.rs:18
  trait laddu_core::utils::vectors::ThreeVector, previously in file /tmp/.tmpcIymIG/laddu-core/src/utils/vectors.rs:51
  trait laddu_core::traits::ThreeVector, previously in file /tmp/.tmpcIymIG/laddu-core/src/utils/vectors.rs:51
  trait laddu_core::utils::vectors::FourVector, previously in file /tmp/.tmpcIymIG/laddu-core/src/utils/vectors.rs:6
  trait laddu_core::traits::FourVector, previously in file /tmp/.tmpcIymIG/laddu-core/src/utils/vectors.rs:6
  trait laddu_core::utils::vectors::ThreeMomentum, previously in file /tmp/.tmpcIymIG/laddu-core/src/utils/vectors.rs:67
  trait laddu_core::traits::ThreeMomentum, previously in file /tmp/.tmpcIymIG/laddu-core/src/utils/vectors.rs:67
```

### ⚠ `laddu-extensions` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/inherent_method_missing.ron

Failed in:
  PyMCMCObserver::new, previously in file /tmp/.tmpcIymIG/laddu-extensions/src/ganesh_ext.rs:378
  PyObserver::new, previously in file /tmp/.tmpcIymIG/laddu-extensions/src/ganesh_ext.rs:366
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu`

<blockquote>

## [0.2.7](https://github.com/denehoffman/laddu/compare/laddu-v0.2.6...laddu-v0.2.7) - 2025-02-21

### Added

- update MPI code to use root-node-agnostic methods
- first pass implementation of MPI interface
- switch the MPI implementation to use safe Rust via a RwLock

### Fixed

- add sentry dependency for which to force the version, not sure what the best fix really is, but this should work for now
- calling get_world before use_mpi causes errors
- correct the open method and counts/displs methods

### Other

- update all documentation to include MPI modules
- add some clippy lints and clean up some unused imports and redundant code
- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
- update benchmark to only run on powers of 2 threads
- *(vectors)* complete tests for vectors module
- *(vectors)* add more vector test coverage
- *(ganesh_ext)* documenting a few missed functions
- use elided lifetimes
</blockquote>

## `laddu-amplitudes`

<blockquote>

## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.5...laddu-amplitudes-v0.2.6) - 2025-02-21

### Other

- update all documentation to include MPI modules
- add some clippy lints and clean up some unused imports and redundant code
</blockquote>

## `laddu-core`

<blockquote>

## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.2.5...laddu-core-v0.3.0) - 2025-02-21

### Added

- switch the MPI implementation to use safe Rust via a RwLock
- update MPI code to use root-node-agnostic methods
- first pass implementation of MPI interface

### Fixed

- calling get_world before use_mpi causes errors
- correct the open method and counts/displs methods

### Other

- *(vectors)* complete tests for vectors module
- *(vectors)* add more vector test coverage
- update all documentation to include MPI modules
- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
</blockquote>

## `laddu-python`

<blockquote>

## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.5...laddu-python-v0.2.6) - 2025-02-21

### Added

- update MPI code to use root-node-agnostic methods
- first pass implementation of MPI interface

### Fixed

- forgot to update the `laddu-python` `use_mpi` function to have a trigger arg
- add feature flag to `laddu-python` and update MSRV for `mpisys` compatibility

### Other

- update all documentation to include MPI modules
- add some clippy lints and clean up some unused imports and redundant code
- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
</blockquote>

## `laddu-extensions`

<blockquote>

## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.6...laddu-extensions-v0.3.0) - 2025-02-21

### Added

- update MPI code to use root-node-agnostic methods
- first pass implementation of MPI interface

### Other

- *(ganesh_ext)* documenting a few missed functions
- update all documentation to include MPI modules
- add some clippy lints and clean up some unused imports and redundant code
- use elided lifetimes
</blockquote>

## `py-laddu`

<blockquote>

## [0.2.7](https://github.com/denehoffman/laddu/compare/py-laddu-v0.2.6...py-laddu-v0.2.7) - 2025-02-21

### Added

- make `mpi` a feature in `py-laddu` to allow people to build the python package without it
- update MPI code to use root-node-agnostic methods
- first pass implementation of MPI interface
- switch the MPI implementation to use safe Rust via a RwLock

### Fixed

- add non-MPI failing functions for MPI calls on non-MPI python builds
- add mpi feature for laddu-python to py-laddu
- calling get_world before use_mpi causes errors
- correct the open method and counts/displs methods

### Other

- update all documentation to include MPI modules
- add mpich to builds
- *(vectors)* complete tests for vectors module
- *(vectors)* add more vector test coverage
- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
- add some clippy lints and clean up some unused imports and redundant code
- *(ganesh_ext)* documenting a few missed functions
- use elided lifetimes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).