### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.3.0", path = "crates/laddu" }
-laddu-core = { version = "0.3.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.3.0", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.3.0", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.3.0", path = "crates/laddu-python" }
+laddu = { version = "0.3.1", path = "crates/laddu" }
+laddu-core = { version = "0.4.0", path = "crates/laddu-core" }
+laddu-amplitudes = { version = "0.3.1", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.3.1", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.3.1", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.3.1", path = "crates/laddu" }
+laddu = { version = "0.4.0", path = "crates/laddu" }
 laddu-core = { version = "0.4.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.3.1", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.3.1", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.3.1", path = "crates/laddu-python" }
+laddu-amplitudes = { version = "0.4.0", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.4.0", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.4.0", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.3.0...laddu-amplitudes-v0.3.1) - 2025-02-28
+
+### Added
+
+- redefine eps->aux in `Event` definition
+
 ## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.2.5...laddu-amplitudes-v0.3.0) - 2025-02-21
 
 ### Other

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.3.0...laddu-amplitudes-v0.3.1) - 2025-02-28
+## [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.3.0...laddu-amplitudes-v0.3.1) - 2025-02-28
 
 ### Added
 

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.3.1"
+version = "0.4.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-core/CHANGELOG.md
+++ b/crates/laddu-core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.3.0...laddu-core-v0.4.0) - 2025-02-28
+
+### Added
+
+- redefine eps->aux in `Event` definition
+
+### Other
+
+- finalize conversion of eps->aux in data formatting
+
 ## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.2.5...laddu-core-v0.3.0) - 2025-02-21
 
 ### Added

--- a/crates/laddu-core/Cargo.toml
+++ b/crates/laddu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-core"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.3.0...laddu-extensions-v0.3.1) - 2025-02-28
+
+### Other
+
+- fix citation formatting
+
 ## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.2.6...laddu-extensions-v0.3.0) - 2025-02-21
 
 ### Added

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.3.0...laddu-extensions-v0.3.1) - 2025-02-28
+## [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.3.0...laddu-extensions-v0.3.1) - 2025-02-28
 
 ### Other
 
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(ganesh_ext)* documenting a few missed functions
+- _(ganesh_ext)_ documenting a few missed functions
 - update all documentation to include MPI modules
 - add some clippy lints and clean up some unused imports and redundant code
 - use elided lifetimes
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- bump `ganesh`  to add "skip_hessian" minimization option to skip calculation of Hessian matrix
+- bump `ganesh` to add "skip_hessian" minimization option to skip calculation of Hessian matrix
 
 ### Fixed
 

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.3.1"
+version = "0.4.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.3.0...laddu-python-v0.3.1) - 2025-02-28
+3# [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.3.0...laddu-python-v0.3.1) - 2025-02-28
 
 ### Added
 
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - update all documentation to include MPI modules
 - add some clippy lints and clean up some unused imports and redundant code
-- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
+- _(vectors)_ use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
 
 ## [0.2.5](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.4...laddu-python-v0.2.5) - 2025-01-28
 

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.3.0...laddu-python-v0.3.1) - 2025-02-28
+
+### Added
+
+- redefine eps->aux in `Event` definition
+
+### Other
+
+- move all MPI code to `laddu-python` to make sure MPI docs build properly
+
 ## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.2.5...laddu-python-v0.3.0) - 2025-02-21
 
 ### Added

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.3.0"
+version = "0.3.1"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.3.1"
+version = "0.4.0"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-v0.3.0...laddu-v0.3.1) - 2025-02-28
+
+### Added
+
+- redefine eps->aux in `Event` definition
+
+### Other
+
+- finalize conversion of eps->aux in data formatting
+- fix citation formatting
+
 ## [0.3.0](https://github.com/denehoffman/laddu/compare/laddu-v0.2.6...laddu-v0.3.0) - 2025-02-21
 
 ### Added

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-v0.3.0...laddu-v0.3.1) - 2025-02-28
+## [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-v0.3.0...laddu-v0.3.1) - 2025-02-28
 
 ### Added
 
@@ -36,18 +36,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - update all documentation to include MPI modules
 - add some clippy lints and clean up some unused imports and redundant code
-- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
+- _(vectors)_ use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
 - update benchmark to only run on powers of 2 threads
-- *(vectors)* complete tests for vectors module
-- *(vectors)* add more vector test coverage
-- *(ganesh_ext)* documenting a few missed functions
+- _(vectors)_ complete tests for vectors module
+- _(vectors)_ add more vector test coverage
+- _(ganesh_ext)_ documenting a few missed functions
 - use elided lifetimes
 
 ## [0.2.6](https://github.com/denehoffman/laddu/compare/laddu-v0.2.5...laddu-v0.2.6) - 2025-01-28
 
 ### Added
 
-- bump `ganesh`  to add "skip_hessian" minimization option to skip calculation of Hessian matrix
+- bump `ganesh` to add "skip_hessian" minimization option to skip calculation of Hessian matrix
 
 ### Fixed
 
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - update dependencies and remove `rand` and `rand_chacha`
-- *(data)* fix bootstrap tests by changing seed
+- _(data)_ fix bootstrap tests by changing seed
 
 ## [0.2.4](https://github.com/denehoffman/laddu/compare/laddu-v0.2.3...laddu-v0.2.4) - 2025-01-26
 

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.3.0"
+version = "0.3.1"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.3.1"
+version = "0.4.0"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0](https://github.com/denehoffman/laddu/releases/tag/py-laddu-mpi-v0.3.0) - 2025-02-28
+## [0.4.0](https://github.com/denehoffman/laddu/releases/tag/py-laddu-mpi-v0.3.0) - 2025-02-28
 
 ### Fixed
 

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0](https://github.com/denehoffman/laddu/releases/tag/py-laddu-mpi-v0.3.0) - 2025-02-28
+
+### Fixed
+
+- reorganize package structure

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.3.0...py-laddu-v0.3.1) - 2025-02-28
+
+### Added
+
+- split `laddu` python package into two, with and without MPI support
+- redefine eps->aux in `Event` definition
+
+### Fixed
+
+- reorganize package structure
+
+### Other
+
+- move all MPI code to `laddu-python` to make sure MPI docs build properly
+- finalize conversion of eps->aux in data formatting
+- fix citation formatting
+
 ## [0.3.0](https://github.com/denehoffman/laddu/compare/py-laddu-v0.2.6...py-laddu-v0.3.0) - 2025-02-21
 
 ### Added

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.3.0...py-laddu-v0.3.1) - 2025-02-28
+## [0.4.0](https://github.com/denehoffman/laddu/compare/py-laddu-v0.3.0...py-laddu-v0.3.1) - 2025-02-28
 
 ### Added
 
@@ -44,18 +44,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - update all documentation to include MPI modules
 - add mpich to builds
-- *(vectors)* complete tests for vectors module
-- *(vectors)* add more vector test coverage
-- *(vectors)* use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
+- _(vectors)_ complete tests for vectors module
+- _(vectors)_ add more vector test coverage
+- _(vectors)_ use custom type for 3/4-vectors rather than trait impl for nalgebra Vectors
 - add some clippy lints and clean up some unused imports and redundant code
-- *(ganesh_ext)* documenting a few missed functions
+- _(ganesh_ext)_ documenting a few missed functions
 - use elided lifetimes
 
 ## [0.2.6](https://github.com/denehoffman/laddu/compare/py-laddu-v0.2.5...py-laddu-v0.2.6) - 2025-01-28
 
 ### Added
 
-- bump `ganesh`  to add "skip_hessian" minimization option to skip calculation of Hessian matrix
+- bump `ganesh` to add "skip_hessian" minimization option to skip calculation of Hessian matrix
 
 ### Fixed
 
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(data)* fix bootstrap tests by changing seed
+- _(data)_ fix bootstrap tests by changing seed
 - update dependencies and remove `rand` and `rand_chacha`
 
 ## [0.2.4](https://github.com/denehoffman/laddu/releases/tag/py-laddu-v0.2.4) - 2025-01-26
@@ -92,11 +92,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - bump py-laddu version
-- *(py-laddu)* release v0.2.3
+- _(py-laddu)_ release v0.2.3
 - manually update py-laddu version
 - omit tests and docs in python coverage
 - correct path of extensions module
-- *(py-laddu)* release v0.2.0
+- _(py-laddu)_ release v0.2.0
 - release all crates manually
 - release-plz does not like the way I've set up the workspace. I've looked at conda/rattler for some inspiration, but I might need to manually publish each crate once to get the ball rolling
 - add rust version to py-laddu
@@ -120,7 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - manually update py-laddu version
 - omit tests and docs in python coverage
 - correct path of extensions module
-- *(py-laddu)* release v0.2.0
+- _(py-laddu)_ release v0.2.0
 - release all crates manually
 - release-plz does not like the way I've set up the workspace. I've looked at conda/rattler for some inspiration, but I might need to manually publish each crate once to get the ball rolling
 - add rust version to py-laddu
@@ -138,10 +138,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - bump version
-- *(py-laddu)* release v0.2.1
+- _(py-laddu)_ release v0.2.1
 - force version bump
 - fix python docs to use "extensions" rather than "likelihoods"
-- *(py-laddu)* release v0.2.0
+- _(py-laddu)_ release v0.2.0
 - release all crates manually
 - release-plz does not like the way I've set up the workspace. I've looked at conda/rattler for some inspiration, but I might need to manually publish each crate once to get the ball rolling
 - add rust version to py-laddu
@@ -160,7 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - force version bump
 - fix python docs to use "extensions" rather than "likelihoods"
-- *(py-laddu)* release v0.2.0
+- _(py-laddu)_ release v0.2.0
 - release all crates manually
 - release-plz does not like the way I've set up the workspace. I've looked at conda/rattler for some inspiration, but I might need to manually publish each crate once to get the ball rolling
 - add rust version to py-laddu

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu-core`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `laddu-python`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `laddu-amplitudes`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `laddu-extensions`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `laddu`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `py-laddu`: 0.3.0 -> 0.3.1
* `py-laddu-mpi`: 0.3.0

### ⚠ `laddu-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Event.aux in /tmp/.tmpPg6wkk/laddu/crates/laddu-core/src/data.rs:63
  field Event.aux in /tmp/.tmpPg6wkk/laddu/crates/laddu-core/src/data.rs:63

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_parameter_count_changed.ron

Failed in:
  laddu_core::utils::variables::PolAngle::new now takes 3 parameters instead of 2, in /tmp/.tmpPg6wkk/laddu/crates/laddu-core/src/utils/variables.rs:297
  laddu_core::PolAngle::new now takes 3 parameters instead of 2, in /tmp/.tmpPg6wkk/laddu/crates/laddu-core/src/utils/variables.rs:297
  laddu_core::utils::variables::Polarization::new now takes 3 parameters instead of 2, in /tmp/.tmpPg6wkk/laddu/crates/laddu-core/src/utils/variables.rs:352
  laddu_core::Polarization::new now takes 3 parameters instead of 2, in /tmp/.tmpPg6wkk/laddu/crates/laddu-core/src/utils/variables.rs:352

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field eps of struct Event, previously in file /tmp/.tmpaHD7ek/laddu-core/src/data.rs:60
  field eps of struct Event, previously in file /tmp/.tmpaHD7ek/laddu-core/src/data.rs:60
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu-core`

<blockquote>

## [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.3.0...laddu-core-v0.4.0) - 2025-02-28

### Added

- redefine eps->aux in `Event` definition

### Other

- finalize conversion of eps->aux in data formatting
</blockquote>

## `laddu-python`

<blockquote>

## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.3.0...laddu-python-v0.3.1) - 2025-02-28

### Added

- redefine eps->aux in `Event` definition

### Other

- move all MPI code to `laddu-python` to make sure MPI docs build properly
</blockquote>

## `laddu-amplitudes`

<blockquote>

## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.3.0...laddu-amplitudes-v0.3.1) - 2025-02-28

### Added

- redefine eps->aux in `Event` definition
</blockquote>

## `laddu-extensions`

<blockquote>

## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.3.0...laddu-extensions-v0.3.1) - 2025-02-28

### Other

- fix citation formatting
</blockquote>

## `laddu`

<blockquote>

## [0.3.1](https://github.com/denehoffman/laddu/compare/laddu-v0.3.0...laddu-v0.3.1) - 2025-02-28

### Added

- redefine eps->aux in `Event` definition

### Other

- finalize conversion of eps->aux in data formatting
- fix citation formatting
</blockquote>

## `py-laddu`

<blockquote>

## [0.3.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.3.0...py-laddu-v0.3.1) - 2025-02-28

### Added

- split `laddu` python package into two, with and without MPI support
- redefine eps->aux in `Event` definition

### Fixed

- reorganize package structure

### Other

- move all MPI code to `laddu-python` to make sure MPI docs build properly
- finalize conversion of eps->aux in data formatting
- fix citation formatting
</blockquote>

## `py-laddu-mpi`

<blockquote>

## [0.3.0](https://github.com/denehoffman/laddu/releases/tag/py-laddu-mpi-v0.3.0) - 2025-02-28

### Fixed

- reorganize package structure
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).