### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.4.0", path = "crates/laddu" }
+laddu = { version = "0.4.1", path = "crates/laddu" }
 laddu-core = { version = "0.4.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.4.0", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.4.0", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.4.0", path = "crates/laddu-python" }
+laddu-amplitudes = { version = "0.4.1", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.4.1", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.4.1", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.4.0...laddu-amplitudes-v0.4.1) - 2025-03-04
+
+### Added
+
+- add `PhaseSpaceFactor` amplitude
+
 ## [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.3.0...laddu-amplitudes-v0.3.1) - 2025-02-28
 
 ### Added

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.4.0...laddu-extensions-v0.4.1) - 2025-03-04
+
+### Other
+
+- updated the following local packages: laddu-python
+
 ## [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.3.0...laddu-extensions-v0.3.1) - 2025-02-28
 
 ### Other

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.4.0...laddu-python-v0.4.1) - 2025-03-04
+
+### Fixed
+
+- get rid of unused variable warning
+
 3# [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.3.0...laddu-python-v0.3.1) - 2025-02-28
 
 ### Added

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.4.0"
+version = "0.4.1"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-v0.4.0...laddu-v0.4.1) - 2025-03-04
+
+### Added
+
+- add `PhaseSpaceFactor` amplitude
+
 ## [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-v0.3.0...laddu-v0.3.1) - 2025-02-28
 
 ### Added

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.4.0"
+version = "0.4.1"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.4.0...py-laddu-mpi-v0.4.1) - 2025-03-04
+
+### Added
+
+- add `PhaseSpaceFactor` amplitude
+
 ## [0.4.0](https://github.com/denehoffman/laddu/releases/tag/py-laddu-mpi-v0.3.0) - 2025-02-28
 
 ### Fixed

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.4.0...py-laddu-v0.4.1) - 2025-03-04
+
+### Added
+
+- add `PhaseSpaceFactor` amplitude
+
 ## [0.4.0](https://github.com/denehoffman/laddu/compare/py-laddu-v0.3.0...py-laddu-v0.3.1) - 2025-02-28
 
 ### Added

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu-python`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `laddu-amplitudes`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `laddu`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `py-laddu`: 0.4.0 -> 0.4.1
* `py-laddu-mpi`: 0.4.0 -> 0.4.1
* `laddu-extensions`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu-python`

<blockquote>

## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.4.0...laddu-python-v0.4.1) - 2025-03-04

### Fixed

- get rid of unused variable warning

3# [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.3.0...laddu-python-v0.3.1) - 2025-02-28

### Added

- redefine eps->aux in `Event` definition

### Other

- move all MPI code to `laddu-python` to make sure MPI docs build properly
</blockquote>

## `laddu-amplitudes`

<blockquote>

## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.4.0...laddu-amplitudes-v0.4.1) - 2025-03-04

### Added

- add `PhaseSpaceFactor` amplitude
</blockquote>

## `laddu`

<blockquote>

## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-v0.4.0...laddu-v0.4.1) - 2025-03-04

### Added

- add `PhaseSpaceFactor` amplitude
</blockquote>

## `py-laddu`

<blockquote>

## [0.4.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.4.0...py-laddu-v0.4.1) - 2025-03-04

### Added

- add `PhaseSpaceFactor` amplitude
</blockquote>

## `py-laddu-mpi`

<blockquote>

## [0.4.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.4.0...py-laddu-mpi-v0.4.1) - 2025-03-04

### Added

- add `PhaseSpaceFactor` amplitude
</blockquote>

## `laddu-extensions`

<blockquote>

## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.4.0...laddu-extensions-v0.4.1) - 2025-03-04

### Other

- updated the following local packages: laddu-python
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).