### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.4.1", path = "crates/laddu" }
-laddu-core = { version = "0.4.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.4.1", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.4.1", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.4.1", path = "crates/laddu-python" }
+laddu = { version = "0.4.2", path = "crates/laddu" }
+laddu-core = { version = "0.5.0", path = "crates/laddu-core" }
+laddu-amplitudes = { version = "0.4.2", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.5.0", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.4.2", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.4.2", path = "crates/laddu" }
+laddu = { version = "0.5.0", path = "crates/laddu" }
 laddu-core = { version = "0.5.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.4.2", path = "crates/laddu-amplitudes" }
+laddu-amplitudes = { version = "0.5.0", path = "crates/laddu-amplitudes" }
 laddu-extensions = { version = "0.5.0", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.4.2", path = "crates/laddu-python" }
+laddu-python = { version = "0.5.0", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.4.1...laddu-amplitudes-v0.4.2) - 2025-03-13
+
+### Other
+
+- ignore excessive precision warnings
+
 ## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.4.0...laddu-amplitudes-v0.4.1) - 2025-03-04
 
 ### Added

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.4.2"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.4.1"
+version = "0.4.2"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-core/CHANGELOG.md
+++ b/crates/laddu-core/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.4.0...laddu-core-v0.5.0) - 2025-03-13
+
+### Added
+
+- display the AmplitudeID's name and ID together
+- add unit-valued `Expression` and define convenience methods for summing and multiplying lists of `Amplitude`s
+- add `Debug` and `Display` to every `Variable` (and require them for new ones)
+
+### Fixed
+
+- update GradientValues in non-default feature branches
+- correct gradients of zero and one by adding the number of parameters into `GradientValues`
+
+### Other
+
+- *(amplitudes)* expand gradient test to cover more complex cases and add tests for zeros, ones, sums and products
+- *(amplitudes)* add test for printing expressions
+- *(variables)* add tests for `Variable` Display impls
+- *(data)* fix tests by implementing Debug/Display for testing variable
+- ignore excessive precision warnings
+
 ## [0.4.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.3.0...laddu-core-v0.4.0) - 2025-02-28
 
 ### Added

--- a/crates/laddu-core/Cargo.toml
+++ b/crates/laddu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-core"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.4.1...laddu-extensions-v0.5.0) - 2025-03-13
+
+### Added
+
+- add the ability to name likelihood terms and convenience methods for null and unit likelihood terms, sums, and products
+
+### Fixed
+
+- update GradientValues in non-default feature branches (missed one)
+- update GradientValues in non-default feature branches
+- correct gradients of zero and one by adding the number of parameters into `GradientValues`
+- improve summation and product methods to only return a Zero or One if the list is empty
+- change `LikelihoodTerm` naming to happen at registration time
+- add python feature gate to likelihood-related methods
+
+### Other
+
+- *(likelihoods)* fix typo in `NLL` documentation
+
 ## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.4.0...laddu-extensions-v0.4.1) - 2025-03-04
 
 ### Other

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/denehoffman/laddu/compare/laddu-python-v0.4.1...laddu-python-v0.4.2) - 2025-03-13
+
+### Added
+
+- add unit-valued `Expression` and define convenience methods for summing and multiplying lists of `Amplitude`s
+- add `Debug` and `Display` to every `Variable` (and require them for new ones)
+
+### Fixed
+
+- improve summation and product methods to only return a Zero or One if the list is empty
+
 ## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.4.0...laddu-python-v0.4.1) - 2025-03-04
 
 ### Fixed

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.4.1"
+version = "0.4.2"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.4.2"
+version = "0.5.0"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/denehoffman/laddu/compare/laddu-v0.4.1...laddu-v0.4.2) - 2025-03-13
+
+### Added
+
+- display the AmplitudeID's name and ID together
+- add unit-valued `Expression` and define convenience methods for summing and multiplying lists of `Amplitude`s
+- add `Debug` and `Display` to every `Variable` (and require them for new ones)
+- add the ability to name likelihood terms and convenience methods for null and unit likelihood terms, sums, and products
+
+### Fixed
+
+- update GradientValues in non-default feature branches
+- correct gradients of zero and one by adding the number of parameters into `GradientValues`
+- update GradientValues in non-default feature branches (missed one)
+- improve summation and product methods to only return a Zero or One if the list is empty
+- change `LikelihoodTerm` naming to happen at registration time
+- add python feature gate to likelihood-related methods
+
+### Other
+
+- *(amplitudes)* expand gradient test to cover more complex cases and add tests for zeros, ones, sums and products
+- *(amplitudes)* add test for printing expressions
+- *(variables)* add tests for `Variable` Display impls
+- *(data)* fix tests by implementing Debug/Display for testing variable
+- ignore excessive precision warnings
+- *(likelihoods)* fix typo in `NLL` documentation
+
 ## [0.4.1](https://github.com/denehoffman/laddu/compare/laddu-v0.4.0...laddu-v0.4.1) - 2025-03-04
 
 ### Added

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.4.2"
+version = "0.5.0"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.4.1"
+version = "0.4.2"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.4.1...py-laddu-mpi-v0.4.2) - 2025-03-13
+
+### Added
+
+- display the AmplitudeID's name and ID together
+- add unit-valued `Expression` and define convenience methods for summing and multiplying lists of `Amplitude`s
+- add `Debug` and `Display` to every `Variable` (and require them for new ones)
+- add the ability to name likelihood terms and convenience methods for null and unit likelihood terms, sums, and products
+
+### Fixed
+
+- update GradientValues in non-default feature branches
+- correct gradients of zero and one by adding the number of parameters into `GradientValues`
+- update GradientValues in non-default feature branches (missed one)
+- improve summation and product methods to only return a Zero or One if the list is empty
+- change `LikelihoodTerm` naming to happen at registration time
+- add python feature gate to likelihood-related methods
+
+### Other
+
+- *(amplitudes)* expand gradient test to cover more complex cases and add tests for zeros, ones, sums and products
+- *(amplitudes)* add test for printing expressions
+- *(variables)* add tests for `Variable` Display impls
+- *(data)* fix tests by implementing Debug/Display for testing variable
+- ignore excessive precision warnings
+- *(likelihoods)* fix typo in `NLL` documentation
+
 ## [0.4.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.4.0...py-laddu-mpi-v0.4.1) - 2025-03-04
 
 ### Added

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.4.2"
+version = "0.5.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/denehoffman/laddu/compare/py-laddu-v0.4.1...py-laddu-v0.4.2) - 2025-03-13
+
+### Added
+
+- add unit-valued `Expression` and define convenience methods for summing and multiplying lists of `Amplitude`s
+- add the ability to name likelihood terms and convenience methods for null and unit likelihood terms, sums, and products
+- display the AmplitudeID's name and ID together
+- add `Debug` and `Display` to every `Variable` (and require them for new ones)
+
+### Fixed
+
+- update GradientValues in non-default feature branches
+- correct gradients of zero and one by adding the number of parameters into `GradientValues`
+- update GradientValues in non-default feature branches (missed one)
+- improve summation and product methods to only return a Zero or One if the list is empty
+- change `LikelihoodTerm` naming to happen at registration time
+- add python feature gate to likelihood-related methods
+
+### Other
+
+- *(amplitudes)* expand gradient test to cover more complex cases and add tests for zeros, ones, sums and products
+- *(amplitudes)* add test for printing expressions
+- *(variables)* add tests for `Variable` Display impls
+- *(data)* fix tests by implementing Debug/Display for testing variable
+- ignore excessive precision warnings
+- *(likelihoods)* fix typo in `NLL` documentation
+
 ## [0.4.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.4.0...py-laddu-v0.4.1) - 2025-03-04
 
 ### Added

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.4.2"
+version = "0.5.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu-core`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `laddu-python`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `laddu-amplitudes`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `laddu-extensions`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `laddu`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `py-laddu`: 0.4.1 -> 0.4.2
* `py-laddu-mpi`: 0.4.1 -> 0.4.2

### ⚠ `laddu-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GradientValues.1 in /tmp/.tmp5m1jLF/laddu/crates/laddu-core/src/amplitudes.rs:196

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_variant_added.ron

Failed in:
  variant Expression:One in /tmp/.tmp5m1jLF/laddu/crates/laddu-core/src/amplitudes.rs:222
  variant Expression:One in /tmp/.tmp5m1jLF/laddu/crates/laddu-core/src/amplitudes.rs:222

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait laddu_core::utils::variables::Variable gained Debug in file /tmp/.tmp5m1jLF/laddu/crates/laddu-core/src/utils/variables.rs:26
  trait laddu_core::utils::variables::Variable gained Display in file /tmp/.tmp5m1jLF/laddu/crates/laddu-core/src/utils/variables.rs:26
  trait laddu_core::traits::Variable gained Debug in file /tmp/.tmp5m1jLF/laddu/crates/laddu-core/src/utils/variables.rs:26
  trait laddu_core::traits::Variable gained Display in file /tmp/.tmp5m1jLF/laddu/crates/laddu-core/src/utils/variables.rs:26
```

### ⚠ `laddu-extensions` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_variant_added.ron

Failed in:
  variant LikelihoodExpression:Zero in /tmp/.tmp5m1jLF/laddu/crates/laddu-extensions/src/likelihoods.rs:1977
  variant LikelihoodExpression:One in /tmp/.tmp5m1jLF/laddu/crates/laddu-extensions/src/likelihoods.rs:1979
  variant LikelihoodExpression:Zero in /tmp/.tmp5m1jLF/laddu/crates/laddu-extensions/src/likelihoods.rs:1977
  variant LikelihoodExpression:One in /tmp/.tmp5m1jLF/laddu/crates/laddu-extensions/src/likelihoods.rs:1979
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu-core`

<blockquote>

## [0.5.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.4.0...laddu-core-v0.5.0) - 2025-03-13

### Added

- display the AmplitudeID's name and ID together
- add unit-valued `Expression` and define convenience methods for summing and multiplying lists of `Amplitude`s
- add `Debug` and `Display` to every `Variable` (and require them for new ones)

### Fixed

- update GradientValues in non-default feature branches
- correct gradients of zero and one by adding the number of parameters into `GradientValues`

### Other

- *(amplitudes)* expand gradient test to cover more complex cases and add tests for zeros, ones, sums and products
- *(amplitudes)* add test for printing expressions
- *(variables)* add tests for `Variable` Display impls
- *(data)* fix tests by implementing Debug/Display for testing variable
- ignore excessive precision warnings
</blockquote>

## `laddu-python`

<blockquote>

## [0.4.2](https://github.com/denehoffman/laddu/compare/laddu-python-v0.4.1...laddu-python-v0.4.2) - 2025-03-13

### Added

- add unit-valued `Expression` and define convenience methods for summing and multiplying lists of `Amplitude`s
- add `Debug` and `Display` to every `Variable` (and require them for new ones)

### Fixed

- improve summation and product methods to only return a Zero or One if the list is empty
</blockquote>

## `laddu-amplitudes`

<blockquote>

## [0.4.2](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.4.1...laddu-amplitudes-v0.4.2) - 2025-03-13

### Other

- ignore excessive precision warnings
</blockquote>

## `laddu-extensions`

<blockquote>

## [0.5.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.4.1...laddu-extensions-v0.5.0) - 2025-03-13

### Added

- add the ability to name likelihood terms and convenience methods for null and unit likelihood terms, sums, and products

### Fixed

- update GradientValues in non-default feature branches (missed one)
- update GradientValues in non-default feature branches
- correct gradients of zero and one by adding the number of parameters into `GradientValues`
- improve summation and product methods to only return a Zero or One if the list is empty
- change `LikelihoodTerm` naming to happen at registration time
- add python feature gate to likelihood-related methods

### Other

- *(likelihoods)* fix typo in `NLL` documentation
</blockquote>

## `laddu`

<blockquote>

## [0.4.2](https://github.com/denehoffman/laddu/compare/laddu-v0.4.1...laddu-v0.4.2) - 2025-03-13

### Added

- display the AmplitudeID's name and ID together
- add unit-valued `Expression` and define convenience methods for summing and multiplying lists of `Amplitude`s
- add `Debug` and `Display` to every `Variable` (and require them for new ones)
- add the ability to name likelihood terms and convenience methods for null and unit likelihood terms, sums, and products

### Fixed

- update GradientValues in non-default feature branches
- correct gradients of zero and one by adding the number of parameters into `GradientValues`
- update GradientValues in non-default feature branches (missed one)
- improve summation and product methods to only return a Zero or One if the list is empty
- change `LikelihoodTerm` naming to happen at registration time
- add python feature gate to likelihood-related methods

### Other

- *(amplitudes)* expand gradient test to cover more complex cases and add tests for zeros, ones, sums and products
- *(amplitudes)* add test for printing expressions
- *(variables)* add tests for `Variable` Display impls
- *(data)* fix tests by implementing Debug/Display for testing variable
- ignore excessive precision warnings
- *(likelihoods)* fix typo in `NLL` documentation
</blockquote>

## `py-laddu`

<blockquote>

## [0.4.2](https://github.com/denehoffman/laddu/compare/py-laddu-v0.4.1...py-laddu-v0.4.2) - 2025-03-13

### Added

- add unit-valued `Expression` and define convenience methods for summing and multiplying lists of `Amplitude`s
- add the ability to name likelihood terms and convenience methods for null and unit likelihood terms, sums, and products
- display the AmplitudeID's name and ID together
- add `Debug` and `Display` to every `Variable` (and require them for new ones)

### Fixed

- update GradientValues in non-default feature branches
- correct gradients of zero and one by adding the number of parameters into `GradientValues`
- update GradientValues in non-default feature branches (missed one)
- improve summation and product methods to only return a Zero or One if the list is empty
- change `LikelihoodTerm` naming to happen at registration time
- add python feature gate to likelihood-related methods

### Other

- *(amplitudes)* expand gradient test to cover more complex cases and add tests for zeros, ones, sums and products
- *(amplitudes)* add test for printing expressions
- *(variables)* add tests for `Variable` Display impls
- *(data)* fix tests by implementing Debug/Display for testing variable
- ignore excessive precision warnings
- *(likelihoods)* fix typo in `NLL` documentation
</blockquote>

## `py-laddu-mpi`

<blockquote>

## [0.4.2](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.4.1...py-laddu-mpi-v0.4.2) - 2025-03-13

### Added

- display the AmplitudeID's name and ID together
- add unit-valued `Expression` and define convenience methods for summing and multiplying lists of `Amplitude`s
- add `Debug` and `Display` to every `Variable` (and require them for new ones)
- add the ability to name likelihood terms and convenience methods for null and unit likelihood terms, sums, and products

### Fixed

- update GradientValues in non-default feature branches
- correct gradients of zero and one by adding the number of parameters into `GradientValues`
- update GradientValues in non-default feature branches (missed one)
- improve summation and product methods to only return a Zero or One if the list is empty
- change `LikelihoodTerm` naming to happen at registration time
- add python feature gate to likelihood-related methods

### Other

- *(amplitudes)* expand gradient test to cover more complex cases and add tests for zeros, ones, sums and products
- *(amplitudes)* add test for printing expressions
- *(variables)* add tests for `Variable` Display impls
- *(data)* fix tests by implementing Debug/Display for testing variable
- ignore excessive precision warnings
- *(likelihoods)* fix typo in `NLL` documentation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).