### PR TITLE
Observer error reporting

### DIFF
--- a/crates/laddu-extensions/src/ganesh_ext.rs
+++ b/crates/laddu-extensions/src/ganesh_ext.rs
@@ -924,14 +924,10 @@ pub mod py_ganesh {
         fn callback(&mut self, step: usize, status: &mut Status, _user_data: &mut ()) -> bool {
             let (new_status, result) = Python::with_gil(|py| {
                 let res = self
-                .0
-                .bind(py)
-                .call_method(
-                    "callback",
-                    (step, PyStatus(status.clone())),
-                    None,
-                )
-                .expect("Observer does not have a \"callback(step: int, status: laddu.Status) -> tuple[laddu.Status, bool]\" method!");
+                    .0
+                    .bind(py)
+                    .call_method("callback", (step, PyStatus(status.clone())), None)
+                    .unwrap();
                 let res_tuple = res
                     .downcast::<PyTuple>()
                     .expect("\"callback\" method should return a \"tuple[laddu.Status, bool]\"!");
@@ -963,14 +959,10 @@ pub mod py_ganesh {
         ) -> bool {
             let (new_status, result) = Python::with_gil(|py| {
                 let res = self
-                .0
-                .bind(py)
-                .call_method(
-                    "callback",
-                    (step, PyStatus(status.clone())),
-                    None,
-                )
-                .expect("Observer does not have a \"callback(step: int, status: laddu.Status) -> tuple[laddu.Status, bool]\" method!");
+                    .0
+                    .bind(py)
+                    .call_method("callback", (step, PyStatus(status.clone())), None)
+                    .unwrap();
                 let res_tuple = res
                     .downcast::<PyTuple>()
                     .expect("\"callback\" method should return a \"tuple[laddu.Status, bool]\"!");
@@ -1000,14 +992,10 @@ pub mod py_ganesh {
         fn callback(&mut self, step: usize, ensemble: &mut Ensemble, _user_data: &mut ()) -> bool {
             let (new_ensemble, result) = Python::with_gil(|py| {
                 let res = self
-                .0
-                .bind(py)
-                .call_method(
-                    "callback",
-                    (step, PyEnsemble(ensemble.clone())),
-                    None,
-                )
-                .expect("MCMCObserver does not have a \"callback(step: int, status: laddu.Ensemble) -> tuple[laddu.Ensemble, bool]\" method!");
+                    .0
+                    .bind(py)
+                    .call_method("callback", (step, PyEnsemble(ensemble.clone())), None)
+                    .unwrap();
                 let res_tuple = res
                     .downcast::<PyTuple>()
                     .expect("\"callback\" method should return a \"tuple[laddu.Status, bool]\"!");
@@ -1040,14 +1028,10 @@ pub mod py_ganesh {
         ) -> bool {
             let (new_ensemble, result) = Python::with_gil(|py| {
                 let res = self
-                .0
-                .bind(py)
-                .call_method(
-                    "callback",
-                    (step, PyEnsemble(ensemble.clone())),
-                    None,
-                )
-                .expect("MCMCObserver does not have a \"callback(step: int, status: laddu.Ensemble) -> tuple[laddu.Ensemble, bool]\" method!");
+                    .0
+                    .bind(py)
+                    .call_method("callback", (step, PyEnsemble(ensemble.clone())), None)
+                    .unwrap();
                 let res_tuple = res
                     .downcast::<PyTuple>()
                     .expect("\"callback\" method should return a \"tuple[laddu.Status, bool]\"!");

--- a/crates/laddu-extensions/src/ganesh_ext.rs
+++ b/crates/laddu-extensions/src/ganesh_ext.rs
@@ -927,7 +927,10 @@ pub mod py_ganesh {
                     .0
                     .bind(py)
                     .call_method("callback", (step, PyStatus(status.clone())), None)
-                    .unwrap();
+                    .unwrap_or_else(|err| {
+                        err.print(py);
+                        panic!("Python error encountered!");
+                    });
                 let res_tuple = res
                     .downcast::<PyTuple>()
                     .expect("\"callback\" method should return a \"tuple[laddu.Status, bool]\"!");
@@ -962,7 +965,10 @@ pub mod py_ganesh {
                     .0
                     .bind(py)
                     .call_method("callback", (step, PyStatus(status.clone())), None)
-                    .unwrap();
+                    .unwrap_or_else(|err| {
+                        err.print(py);
+                        panic!("Python error encountered!");
+                    });
                 let res_tuple = res
                     .downcast::<PyTuple>()
                     .expect("\"callback\" method should return a \"tuple[laddu.Status, bool]\"!");
@@ -995,7 +1001,10 @@ pub mod py_ganesh {
                     .0
                     .bind(py)
                     .call_method("callback", (step, PyEnsemble(ensemble.clone())), None)
-                    .unwrap();
+                    .unwrap_or_else(|err| {
+                        err.print(py);
+                        panic!("Python error encountered!");
+                    });
                 let res_tuple = res
                     .downcast::<PyTuple>()
                     .expect("\"callback\" method should return a \"tuple[laddu.Status, bool]\"!");
@@ -1031,7 +1040,10 @@ pub mod py_ganesh {
                     .0
                     .bind(py)
                     .call_method("callback", (step, PyEnsemble(ensemble.clone())), None)
-                    .unwrap();
+                    .unwrap_or_else(|err| {
+                        err.print(py);
+                        panic!("Python error encountered!");
+                    });
                 let res_tuple = res
                     .downcast::<PyTuple>()
                     .expect("\"callback\" method should return a \"tuple[laddu.Status, bool]\"!");


### PR DESCRIPTION
A pretty quick and simple PR that handles the Python error reporting in `Observer` and `MCMCObserver` in a more coherent manner.

Previously, if an exception occurred inside the `callback` method of a subclass of one of these classes, you would just get a message that said the `callback` method didn't exist. Now it actually gives the stack trace.