### PR TITLE
chore: release v0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,10 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.5.0", path = "crates/laddu" }
+laddu = { version = "0.5.1", path = "crates/laddu" }
 laddu-core = { version = "0.5.0", path = "crates/laddu-core" }
 laddu-amplitudes = { version = "0.5.0", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.5.0", path = "crates/laddu-extensions" }
+laddu-extensions = { version = "0.5.1", path = "crates/laddu-extensions" }
 laddu-python = { version = "0.5.0", path = "crates/laddu-python" }
 
 [profile.release]

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.5.0...laddu-extensions-v0.5.1) - 2025-03-16
+
+### Fixed
+
+- change unwrap to print error and panic
+- unwrap call_method so that it reports the stack trace if the method fails
+
 ## [0.5.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.4.1...laddu-extensions-v0.5.0) - 2025-03-13
 
 ### Added

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.5.0"
+version = "0.5.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-v0.5.0...laddu-v0.5.1) - 2025-03-16
+
+### Fixed
+
+- change unwrap to print error and panic
+- unwrap call_method so that it reports the stack trace if the method fails
+
 ## [0.4.2](https://github.com/denehoffman/laddu/compare/laddu-v0.4.1...laddu-v0.4.2) - 2025-03-13
 
 ### Added

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.5.0"
+version = "0.5.1"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.5.0...py-laddu-mpi-v0.5.1) - 2025-03-16
+
+### Fixed
+
+- change unwrap to print error and panic
+- unwrap call_method so that it reports the stack trace if the method fails
+
 ## [0.4.2](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.4.1...py-laddu-mpi-v0.4.2) - 2025-03-13
 
 ### Added

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.5.0...py-laddu-v0.5.1) - 2025-03-16
+
+### Fixed
+
+- change unwrap to print error and panic
+- unwrap call_method so that it reports the stack trace if the method fails
+
 ## [0.4.2](https://github.com/denehoffman/laddu/compare/py-laddu-v0.4.1...py-laddu-v0.4.2) - 2025-03-13
 
 ### Added

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu-extensions`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `laddu`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `py-laddu`: 0.5.0 -> 0.5.1
* `py-laddu-mpi`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu-extensions`

<blockquote>

## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.5.0...laddu-extensions-v0.5.1) - 2025-03-16

### Fixed

- change unwrap to print error and panic
- unwrap call_method so that it reports the stack trace if the method fails
</blockquote>

## `laddu`

<blockquote>

## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-v0.5.0...laddu-v0.5.1) - 2025-03-16

### Fixed

- change unwrap to print error and panic
- unwrap call_method so that it reports the stack trace if the method fails
</blockquote>

## `py-laddu`

<blockquote>

## [0.5.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.5.0...py-laddu-v0.5.1) - 2025-03-16

### Fixed

- change unwrap to print error and panic
- unwrap call_method so that it reports the stack trace if the method fails
</blockquote>

## `py-laddu-mpi`

<blockquote>

## [0.5.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.5.0...py-laddu-mpi-v0.5.1) - 2025-03-16

### Fixed

- change unwrap to print error and panic
- unwrap call_method so that it reports the stack trace if the method fails
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).