### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.3"
 typetag = "0.2.18"
 
-laddu = { version = "0.5.1", path = "crates/laddu" }
-laddu-core = { version = "0.5.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.5.0", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.5.1", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.5.0", path = "crates/laddu-python" }
+laddu = { version = "0.5.2", path = "crates/laddu" }
+laddu-core = { version = "0.5.1", path = "crates/laddu-core" }
+laddu-amplitudes = { version = "0.5.1", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.5.2", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.5.1", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.5.0...laddu-amplitudes-v0.5.1) - 2025-04-04
+
+### Other
+
+- fix some citations and equations, and add phase_space to the API listing
+
 ## [0.4.2](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.4.1...laddu-amplitudes-v0.4.2) - 2025-03-13
 
 ### Other

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.5.0"
+version = "0.5.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-core/CHANGELOG.md
+++ b/crates/laddu-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-core-v0.5.0...laddu-core-v0.5.1) - 2025-04-04
+
+### Fixed
+
+- more fixes for newest ganesh version
+
 ## [0.5.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.4.0...laddu-core-v0.5.0) - 2025-03-13
 
 ### Added

--- a/crates/laddu-core/Cargo.toml
+++ b/crates/laddu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-core"
-version = "0.5.0"
+version = "0.5.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.5.1...laddu-extensions-v0.5.2) - 2025-04-04
+
+### Added
+
+- add experimental Regularizer likelihood term
+- update ganesh, numpy, and pyo3
+
+### Fixed
+
+- missed a changed path in some ganesh code hidden behind a feature gate
+- more fixes for newest ganesh version
+
+### Other
+
+- Merge pull request #65 from denehoffman/quality-of-life
+- fix some citations and equations, and add phase_space to the API listing
+
 ## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.5.0...laddu-extensions-v0.5.1) - 2025-03-16
 
 ### Fixed

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.5.1"
+version = "0.5.2"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.5.0...laddu-python-v0.5.1) - 2025-04-04
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.4.2](https://github.com/denehoffman/laddu/compare/laddu-python-v0.4.1...laddu-python-v0.4.2) - 2025-03-13
 
 ### Added

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.5.0"
+version = "0.5.1"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/denehoffman/laddu/compare/laddu-v0.5.1...laddu-v0.5.2) - 2025-04-04
+
+### Added
+
+- add experimental Regularizer likelihood term
+- update ganesh, numpy, and pyo3
+
+### Fixed
+
+- more fixes for newest ganesh version
+- missed a changed path in some ganesh code hidden behind a feature gate
+
+### Other
+
+- fix some citations and equations, and add phase_space to the API listing
+- Merge pull request #65 from denehoffman/quality-of-life
+
 ## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-v0.5.0...laddu-v0.5.1) - 2025-03-16
 
 ### Fixed

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.5.1"
+version = "0.5.2"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.5.1...py-laddu-mpi-v0.5.2) - 2025-04-04
+
+### Added
+
+- add experimental Regularizer likelihood term
+- update ganesh, numpy, and pyo3
+
+### Fixed
+
+- more fixes for newest ganesh version
+- missed a changed path in some ganesh code hidden behind a feature gate
+
+### Other
+
+- update Cargo.toml dependencies
+- fix some citations and equations, and add phase_space to the API listing
+- Merge pull request #65 from denehoffman/quality-of-life
+
 ## [0.5.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.5.0...py-laddu-mpi-v0.5.1) - 2025-03-16
 
 ### Fixed

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/denehoffman/laddu/compare/py-laddu-v0.5.1...py-laddu-v0.5.2) - 2025-04-04
+
+### Added
+
+- add experimental Regularizer likelihood term
+- update ganesh, numpy, and pyo3
+
+### Fixed
+
+- more fixes for newest ganesh version
+- missed a changed path in some ganesh code hidden behind a feature gate
+
+### Other
+
+- fix some citations and equations, and add phase_space to the API listing
+- Merge pull request #65 from denehoffman/quality-of-life
+
 ## [0.5.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.5.0...py-laddu-v0.5.1) - 2025-03-16
 
 ### Fixed

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu-core`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `laddu-python`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `laddu-amplitudes`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `laddu-extensions`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `laddu`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `py-laddu`: 0.5.1 -> 0.5.2
* `py-laddu-mpi`: 0.5.1 -> 0.5.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu-core`

<blockquote>

## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-core-v0.5.0...laddu-core-v0.5.1) - 2025-04-04

### Fixed

- more fixes for newest ganesh version
</blockquote>

## `laddu-python`

<blockquote>

## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.5.0...laddu-python-v0.5.1) - 2025-04-04

### Other

- update Cargo.toml dependencies
</blockquote>

## `laddu-amplitudes`

<blockquote>

## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.5.0...laddu-amplitudes-v0.5.1) - 2025-04-04

### Other

- fix some citations and equations, and add phase_space to the API listing
</blockquote>

## `laddu-extensions`

<blockquote>

## [0.5.2](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.5.1...laddu-extensions-v0.5.2) - 2025-04-04

### Added

- add experimental Regularizer likelihood term
- update ganesh, numpy, and pyo3

### Fixed

- missed a changed path in some ganesh code hidden behind a feature gate
- more fixes for newest ganesh version

### Other

- Merge pull request #65 from denehoffman/quality-of-life
- fix some citations and equations, and add phase_space to the API listing
</blockquote>

## `laddu`

<blockquote>

## [0.5.2](https://github.com/denehoffman/laddu/compare/laddu-v0.5.1...laddu-v0.5.2) - 2025-04-04

### Added

- add experimental Regularizer likelihood term
- update ganesh, numpy, and pyo3

### Fixed

- more fixes for newest ganesh version
- missed a changed path in some ganesh code hidden behind a feature gate

### Other

- fix some citations and equations, and add phase_space to the API listing
- Merge pull request #65 from denehoffman/quality-of-life
</blockquote>

## `py-laddu`

<blockquote>

## [0.5.2](https://github.com/denehoffman/laddu/compare/py-laddu-v0.5.1...py-laddu-v0.5.2) - 2025-04-04

### Added

- add experimental Regularizer likelihood term
- update ganesh, numpy, and pyo3

### Fixed

- more fixes for newest ganesh version
- missed a changed path in some ganesh code hidden behind a feature gate

### Other

- fix some citations and equations, and add phase_space to the API listing
- Merge pull request #65 from denehoffman/quality-of-life
</blockquote>

## `py-laddu-mpi`

<blockquote>

## [0.5.2](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.5.1...py-laddu-mpi-v0.5.2) - 2025-04-04

### Added

- add experimental Regularizer likelihood term
- update ganesh, numpy, and pyo3

### Fixed

- more fixes for newest ganesh version
- missed a changed path in some ganesh code hidden behind a feature gate

### Other

- update Cargo.toml dependencies
- fix some citations and equations, and add phase_space to the API listing
- Merge pull request #65 from denehoffman/quality-of-life
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).