### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.12"
 typetag = "0.2.20"
 
-laddu = { version = "0.5.2", path = "crates/laddu" }
-laddu-core = { version = "0.5.1", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.5.1", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.5.2", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.5.1", path = "crates/laddu-python" }
+laddu = { version = "0.5.3", path = "crates/laddu" }
+laddu-core = { version = "0.6.0", path = "crates/laddu-core" }
+laddu-amplitudes = { version = "0.5.2", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.6.0", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.6.0", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ shellexpand = "3.1.0"
 thiserror = "2.0.12"
 typetag = "0.2.20"
 
-laddu = { version = "0.5.3", path = "crates/laddu" }
+laddu = { version = "0.6.0", path = "crates/laddu" }
 laddu-core = { version = "0.6.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.5.2", path = "crates/laddu-amplitudes" }
+laddu-amplitudes = { version = "0.6.0", path = "crates/laddu-amplitudes" }
 laddu-extensions = { version = "0.6.0", path = "crates/laddu-extensions" }
 laddu-python = { version = "0.6.0", path = "crates/laddu-python" }
 

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.5.1...laddu-amplitudes-v0.5.2) - 2025-04-11
+
+### Other
+
+- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
+
 ## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.5.0...laddu-amplitudes-v0.5.1) - 2025-04-04
 
 ### Other

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.5.1"
+version = "0.5.2"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.5.2"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-core/CHANGELOG.md
+++ b/crates/laddu-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.5.1...laddu-core-v0.6.0) - 2025-04-11
+
+### Added
+
+- add Swarm methods to Python API and update other algorithm initialization methods
+- add python versions of Point, Particle, SwarmObserver, and Swarm from ganesh
+
+### Other
+
+- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
+
 ## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-core-v0.5.0...laddu-core-v0.5.1) - 2025-04-04
 
 ### Fixed

--- a/crates/laddu-core/Cargo.toml
+++ b/crates/laddu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-core"
-version = "0.5.1"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.5.2...laddu-extensions-v0.6.0) - 2025-04-11
+
+### Added
+
+- change swarm repr if the swarm is uninitialized to not confuse people
+- bump MSRV (for bincode) and bump all dependency versions
+- add Swarm methods to Python API and update other algorithm initialization methods
+- restructure the minimizer/mcmc methods to no longer take kwargs
+- add python versions of Point, Particle, SwarmObserver, and Swarm from ganesh
+- update `ganesh` version and add Global move to ESS
+
+### Fixed
+
+- remove  from the rayon-free  calls for  and
+- corrected typo where the `VerboseMCMCObserver` implemented `SwarmObserver<()>` rather than the `VerboseSwarmObserver`
+- move some imports under the python feature flag
+
+### Other
+
+- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
+- add a todo
+
 ## [0.5.2](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.5.1...laddu-extensions-v0.5.2) - 2025-04-04
 
 ### Added

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.5.2"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.5.1...laddu-python-v0.6.0) - 2025-04-11
+
+### Other
+
+- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
+
 ## [0.5.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.5.0...laddu-python-v0.5.1) - 2025-04-04
 
 ### Other

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.5.1"
+version = "0.6.0"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/denehoffman/laddu/compare/laddu-v0.5.2...laddu-v0.5.3) - 2025-04-11
+
+### Added
+
+- add Swarm methods to Python API and update other algorithm initialization methods
+- add python versions of Point, Particle, SwarmObserver, and Swarm from ganesh
+- change swarm repr if the swarm is uninitialized to not confuse people
+- bump MSRV (for bincode) and bump all dependency versions
+- restructure the minimizer/mcmc methods to no longer take kwargs
+- update `ganesh` version and add Global move to ESS
+
+### Fixed
+
+- add feature flag to benchmark to allow it to be run with "f32" feature
+- remove  from the rayon-free  calls for  and
+- corrected typo where the `VerboseMCMCObserver` implemented `SwarmObserver<()>` rather than the `VerboseSwarmObserver`
+- move some imports under the python feature flag
+
+### Other
+
+- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
+- add a todo
+
 ## [0.5.2](https://github.com/denehoffman/laddu/compare/laddu-v0.5.1...laddu-v0.5.2) - 2025-04-04
 
 ### Added

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.5.2"
+version = "0.5.3"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.5.3"
+version = "0.6.0"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.5.2...py-laddu-mpi-v0.5.3) - 2025-04-11
+
+### Added
+
+- add Swarm methods to Python API and update other algorithm initialization methods
+- add python versions of Point, Particle, SwarmObserver, and Swarm from ganesh
+- change swarm repr if the swarm is uninitialized to not confuse people
+- bump MSRV (for bincode) and bump all dependency versions
+- restructure the minimizer/mcmc methods to no longer take kwargs
+- update `ganesh` version and add Global move to ESS
+
+### Fixed
+
+- remove  from the rayon-free  calls for  and
+- corrected typo where the `VerboseMCMCObserver` implemented `SwarmObserver<()>` rather than the `VerboseSwarmObserver`
+- move some imports under the python feature flag
+- add a few more missed pyclasses to the py-laddu exports
+- missed AEISMove->AIESMove and condensed the lib.rs file for py-laddu
+- forgot to export MCMC moves
+- the last commit fixed the typo the wrong way, it is AIES
+- correct typo AIES->AEIS in python type checking files
+
+### Other
+
+- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
+- add a todo
+
 ## [0.5.2](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.5.1...py-laddu-mpi-v0.5.2) - 2025-04-04
 
 ### Added

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/denehoffman/laddu/compare/py-laddu-v0.5.2...py-laddu-v0.5.3) - 2025-04-11
+
+### Added
+
+- add Swarm methods to Python API and update other algorithm initialization methods
+- add python versions of Point, Particle, SwarmObserver, and Swarm from ganesh
+- change swarm repr if the swarm is uninitialized to not confuse people
+- bump MSRV (for bincode) and bump all dependency versions
+- restructure the minimizer/mcmc methods to no longer take kwargs
+- update `ganesh` version and add Global move to ESS
+
+### Fixed
+
+- add a few more missed pyclasses to the py-laddu exports
+- missed AEISMove->AIESMove and condensed the lib.rs file for py-laddu
+- forgot to export MCMC moves
+- the last commit fixed the typo the wrong way, it is AIES
+- correct typo AIES->AEIS in python type checking files
+- remove  from the rayon-free  calls for  and
+- corrected typo where the `VerboseMCMCObserver` implemented `SwarmObserver<()>` rather than the `VerboseSwarmObserver`
+- move some imports under the python feature flag
+
+### Other
+
+- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
+- add a todo
+
 ## [0.5.2](https://github.com/denehoffman/laddu/compare/py-laddu-v0.5.1...py-laddu-v0.5.2) - 2025-04-04
 
 ### Added

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu-core`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `laddu-python`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `laddu-amplitudes`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `laddu-extensions`: 0.5.2 -> 0.6.0 (⚠ API breaking changes)
* `laddu`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `py-laddu`: 0.5.2 -> 0.5.3
* `py-laddu-mpi`: 0.5.2 -> 0.5.3

### ⚠ `laddu-core` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant LadduError:EncodeError in /tmp/.tmpv3lK0o/laddu/crates/laddu-core/src/lib.rs:343
  variant LadduError:DecodeError in /tmp/.tmpv3lK0o/laddu/crates/laddu-core/src/lib.rs:346

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_missing.ron

Failed in:
  variant LadduError::SerdeError, previously in file /tmp/.tmprOez8D/laddu-core/src/lib.rs:342

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/feature_missing.ron

Failed in:
  feature num_cpus in the package's Cargo.toml
```

### ⚠ `laddu-python` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/feature_missing.ron

Failed in:
  feature f32 in the package's Cargo.toml
```

### ⚠ `laddu-extensions` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  MCMCOptions::new_ess, previously in file /tmp/.tmprOez8D/laddu-extensions/src/ganesh_ext.rs:233
  MCMCOptions::new_aies, previously in file /tmp/.tmprOez8D/laddu-extensions/src/ganesh_ext.rs:244
  MCMCOptions::with_algorithm, previously in file /tmp/.tmprOez8D/laddu-extensions/src/ganesh_ext.rs:278
  MCMCOptions::new_ess, previously in file /tmp/.tmprOez8D/laddu-extensions/src/ganesh_ext.rs:233
  MCMCOptions::new_aies, previously in file /tmp/.tmprOez8D/laddu-extensions/src/ganesh_ext.rs:244
  MCMCOptions::with_algorithm, previously in file /tmp/.tmprOez8D/laddu-extensions/src/ganesh_ext.rs:278
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu-core`

<blockquote>

## [0.6.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.5.1...laddu-core-v0.6.0) - 2025-04-11

### Added

- add Swarm methods to Python API and update other algorithm initialization methods
- add python versions of Point, Particle, SwarmObserver, and Swarm from ganesh

### Other

- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
</blockquote>

## `laddu-python`

<blockquote>

## [0.6.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.5.1...laddu-python-v0.6.0) - 2025-04-11

### Other

- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
</blockquote>

## `laddu-amplitudes`

<blockquote>

## [0.5.2](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.5.1...laddu-amplitudes-v0.5.2) - 2025-04-11

### Other

- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
</blockquote>

## `laddu-extensions`

<blockquote>

## [0.6.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.5.2...laddu-extensions-v0.6.0) - 2025-04-11

### Added

- change swarm repr if the swarm is uninitialized to not confuse people
- bump MSRV (for bincode) and bump all dependency versions
- add Swarm methods to Python API and update other algorithm initialization methods
- restructure the minimizer/mcmc methods to no longer take kwargs
- add python versions of Point, Particle, SwarmObserver, and Swarm from ganesh
- update `ganesh` version and add Global move to ESS

### Fixed

- remove  from the rayon-free  calls for  and
- corrected typo where the `VerboseMCMCObserver` implemented `SwarmObserver<()>` rather than the `VerboseSwarmObserver`
- move some imports under the python feature flag

### Other

- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
- add a todo
</blockquote>

## `laddu`

<blockquote>

## [0.5.3](https://github.com/denehoffman/laddu/compare/laddu-v0.5.2...laddu-v0.5.3) - 2025-04-11

### Added

- add Swarm methods to Python API and update other algorithm initialization methods
- add python versions of Point, Particle, SwarmObserver, and Swarm from ganesh
- change swarm repr if the swarm is uninitialized to not confuse people
- bump MSRV (for bincode) and bump all dependency versions
- restructure the minimizer/mcmc methods to no longer take kwargs
- update `ganesh` version and add Global move to ESS

### Fixed

- add feature flag to benchmark to allow it to be run with "f32" feature
- remove  from the rayon-free  calls for  and
- corrected typo where the `VerboseMCMCObserver` implemented `SwarmObserver<()>` rather than the `VerboseSwarmObserver`
- move some imports under the python feature flag

### Other

- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
- add a todo
</blockquote>

## `py-laddu`

<blockquote>

## [0.5.3](https://github.com/denehoffman/laddu/compare/py-laddu-v0.5.2...py-laddu-v0.5.3) - 2025-04-11

### Added

- add Swarm methods to Python API and update other algorithm initialization methods
- add python versions of Point, Particle, SwarmObserver, and Swarm from ganesh
- change swarm repr if the swarm is uninitialized to not confuse people
- bump MSRV (for bincode) and bump all dependency versions
- restructure the minimizer/mcmc methods to no longer take kwargs
- update `ganesh` version and add Global move to ESS

### Fixed

- add a few more missed pyclasses to the py-laddu exports
- missed AEISMove->AIESMove and condensed the lib.rs file for py-laddu
- forgot to export MCMC moves
- the last commit fixed the typo the wrong way, it is AIES
- correct typo AIES->AEIS in python type checking files
- remove  from the rayon-free  calls for  and
- corrected typo where the `VerboseMCMCObserver` implemented `SwarmObserver<()>` rather than the `VerboseSwarmObserver`
- move some imports under the python feature flag

### Other

- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
- add a todo
</blockquote>

## `py-laddu-mpi`

<blockquote>

## [0.5.3](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.5.2...py-laddu-mpi-v0.5.3) - 2025-04-11

### Added

- add Swarm methods to Python API and update other algorithm initialization methods
- add python versions of Point, Particle, SwarmObserver, and Swarm from ganesh
- change swarm repr if the swarm is uninitialized to not confuse people
- bump MSRV (for bincode) and bump all dependency versions
- restructure the minimizer/mcmc methods to no longer take kwargs
- update `ganesh` version and add Global move to ESS

### Fixed

- remove  from the rayon-free  calls for  and
- corrected typo where the `VerboseMCMCObserver` implemented `SwarmObserver<()>` rather than the `VerboseSwarmObserver`
- move some imports under the python feature flag
- add a few more missed pyclasses to the py-laddu exports
- missed AEISMove->AIESMove and condensed the lib.rs file for py-laddu
- forgot to export MCMC moves
- the last commit fixed the typo the wrong way, it is AIES
- correct typo AIES->AEIS in python type checking files

### Other

- complete compatibility with newest version of bincode, remove unused dependencies and features across all crates
- add a todo
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).