### PR TITLE
chore: release v0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.12"
 typetag = "0.2.20"
 
-laddu = { version = "0.6.0", path = "crates/laddu" }
+laddu = { version = "0.6.1", path = "crates/laddu" }
 laddu-core = { version = "0.6.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.6.0", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.6.0", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.6.0", path = "crates/laddu-python" }
+laddu-amplitudes = { version = "0.6.1", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.6.1", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.6.1", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.6.0...laddu-amplitudes-v0.6.1) - 2025-04-25
+
+### Other
+
+- updated the following local packages: laddu-python
+
 ## [0.5.2](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.5.1...laddu-amplitudes-v0.5.2) - 2025-04-11
 
 ### Other

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.6.0"
+version = "0.6.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.6.0...laddu-extensions-v0.6.1) - 2025-04-25
+
+### Other
+
+- updated the following local packages: laddu-python
+
 ## [0.6.0](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.5.2...laddu-extensions-v0.6.0) - 2025-04-11
 
 ### Added

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.6.0"
+version = "0.6.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.6.0...laddu-python-v0.6.1) - 2025-04-25
+
+### Added
+
+- add available_parallelism function to python API
+
 ## [0.6.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.5.1...laddu-python-v0.6.0) - 2025-04-11
 
 ### Other

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.6.0"
+version = "0.6.1"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/denehoffman/laddu/compare/laddu-v0.6.0...laddu-v0.6.1) - 2025-04-25
+
+### Other
+
+- updated the following local packages: laddu-amplitudes, laddu-extensions
+
 ## [0.5.3](https://github.com/denehoffman/laddu/compare/laddu-v0.5.2...laddu-v0.5.3) - 2025-04-11
 
 ### Added

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.6.0"
+version = "0.6.1"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.6.0...py-laddu-mpi-v0.6.1) - 2025-04-25
+
+### Added
+
+- add available_parallelism function to python API
+
 ## [0.5.3](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.5.2...py-laddu-mpi-v0.5.3) - 2025-04-11
 
 ### Added

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.6.0...py-laddu-v0.6.1) - 2025-04-25
+
+### Added
+
+- add available_parallelism function to python API
+
 ## [0.5.3](https://github.com/denehoffman/laddu/compare/py-laddu-v0.5.2...py-laddu-v0.5.3) - 2025-04-11
 
 ### Added

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu-python`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `py-laddu`: 0.6.0 -> 0.6.1
* `py-laddu-mpi`: 0.6.0 -> 0.6.1
* `laddu-amplitudes`: 0.6.0 -> 0.6.1
* `laddu-extensions`: 0.6.0 -> 0.6.1
* `laddu`: 0.6.0 -> 0.6.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu-python`

<blockquote>

## [0.6.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.6.0...laddu-python-v0.6.1) - 2025-04-25

### Added

- add available_parallelism function to python API
</blockquote>

## `py-laddu`

<blockquote>

## [0.6.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.6.0...py-laddu-v0.6.1) - 2025-04-25

### Added

- add available_parallelism function to python API
</blockquote>

## `py-laddu-mpi`

<blockquote>

## [0.6.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.6.0...py-laddu-mpi-v0.6.1) - 2025-04-25

### Added

- add available_parallelism function to python API
</blockquote>

## `laddu-amplitudes`

<blockquote>

## [0.6.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.6.0...laddu-amplitudes-v0.6.1) - 2025-04-25

### Other

- updated the following local packages: laddu-python
</blockquote>

## `laddu-extensions`

<blockquote>

## [0.6.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.6.0...laddu-extensions-v0.6.1) - 2025-04-25

### Other

- updated the following local packages: laddu-python
</blockquote>

## `laddu`

<blockquote>

## [0.6.1](https://github.com/denehoffman/laddu/compare/laddu-v0.6.0...laddu-v0.6.1) - 2025-04-25

### Other

- updated the following local packages: laddu-amplitudes, laddu-extensions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).