### PR TITLE
Dataset update

### DIFF
--- a/crates/laddu-core/src/data.rs
+++ b/crates/laddu-core/src/data.rs
@@ -817,10 +817,9 @@ mod tests {
         let event = test_event();
         let event_boosted = event.boost_to_rest_frame_of([1, 2, 3]);
         let p4_sum = event_boosted.get_p4_sum([1, 2, 3]);
-        assert_relative_eq!(p4_sum.px(), 0.0);
-        assert_relative_eq!(p4_sum.py(), 0.0);
-        assert_relative_eq!(p4_sum.pz(), 0.0);
-        assert_relative_eq!(p4_sum.e(), 0.0);
+        assert_relative_eq!(p4_sum.px(), 0.0, epsilon = Float::EPSILON.sqrt());
+        assert_relative_eq!(p4_sum.py(), 0.0, epsilon = Float::EPSILON.sqrt());
+        assert_relative_eq!(p4_sum.pz(), 0.0, epsilon = Float::EPSILON.sqrt());
     }
 
     #[test]
@@ -882,10 +881,9 @@ mod tests {
         let dataset = test_dataset();
         let dataset_boosted = dataset.boost_to_rest_frame_of([1, 2, 3]);
         let p4_sum = dataset_boosted[0].get_p4_sum([1, 2, 3]);
-        assert_relative_eq!(p4_sum.px(), 0.0);
-        assert_relative_eq!(p4_sum.py(), 0.0);
-        assert_relative_eq!(p4_sum.pz(), 0.0);
-        assert_relative_eq!(p4_sum.e(), 0.0);
+        assert_relative_eq!(p4_sum.px(), 0.0, epsilon = Float::EPSILON.sqrt());
+        assert_relative_eq!(p4_sum.py(), 0.0, epsilon = Float::EPSILON.sqrt());
+        assert_relative_eq!(p4_sum.pz(), 0.0, epsilon = Float::EPSILON.sqrt());
     }
 
     #[test]

--- a/crates/laddu-python/src/data.rs
+++ b/crates/laddu-python/src/data.rs
@@ -10,7 +10,7 @@ use pyo3::{
 };
 use std::sync::Arc;
 
-use crate::utils::vectors::{PyVector3, PyVector4};
+use crate::utils::vectors::{PyVec3, PyVec4};
 
 /// A single event
 ///
@@ -20,9 +20,9 @@ use crate::utils::vectors::{PyVector3, PyVector4};
 ///
 /// Parameters
 /// ----------
-/// p4s : list of Vector4
+/// p4s : list of Vec4
 ///     4-momenta of each particle in the event in the overall center-of-momentum frame
-/// eps : list of Vector3
+/// eps : list of Vec3
 ///     3-vectors describing the polarization or helicity of the particles
 ///     given in `p4s`
 /// weight : float
@@ -35,7 +35,7 @@ pub struct PyEvent(pub Arc<Event>);
 #[pymethods]
 impl PyEvent {
     #[new]
-    fn new(p4s: Vec<PyVector4>, eps: Vec<PyVector3>, weight: Float) -> Self {
+    fn new(p4s: Vec<PyVec4>, eps: Vec<PyVec3>, weight: Float) -> Self {
         Self(Arc::new(Event {
             p4s: p4s.into_iter().map(|arr| arr.0).collect(),
             aux: eps.into_iter().map(|arr| arr.0).collect(),
@@ -48,19 +48,15 @@ impl PyEvent {
     /// The list of 4-momenta for each particle in the event
     ///
     #[getter]
-    fn get_p4s(&self) -> Vec<PyVector4> {
-        self.0.p4s.iter().map(|p4| PyVector4(*p4)).collect()
+    fn get_p4s(&self) -> Vec<PyVec4> {
+        self.0.p4s.iter().map(|p4| PyVec4(*p4)).collect()
     }
     /// The list of 3-vectors describing the polarization or helicity of particles in
     /// the event
     ///
     #[getter]
-    fn get_eps(&self) -> Vec<PyVector3> {
-        self.0
-            .aux
-            .iter()
-            .map(|eps_vec| PyVector3(*eps_vec))
-            .collect()
+    fn get_eps(&self) -> Vec<PyVec3> {
+        self.0.aux.iter().map(|eps_vec| PyVec3(*eps_vec)).collect()
     }
     /// The weight of this event relative to others in a Dataset
     ///
@@ -77,11 +73,11 @@ impl PyEvent {
     ///
     /// Returns
     /// -------
-    /// Vector4
+    /// Vec4
     ///     The result of summing the given four-momenta
     ///
-    fn get_p4_sum(&self, indices: Vec<usize>) -> PyVector4 {
-        PyVector4(self.0.get_p4_sum(indices))
+    fn get_p4_sum(&self, indices: Vec<usize>) -> PyVec4 {
+        PyVec4(self.0.get_p4_sum(indices))
     }
     /// Boost all the four-momenta in the event to the rest frame of the given set of
     /// four-momenta by indices.

--- a/crates/laddu-python/src/utils/variables.rs
+++ b/crates/laddu-python/src/utils/variables.rs
@@ -68,7 +68,7 @@ impl Display for PyVariable {
 ///
 /// See Also
 /// --------
-/// laddu.utils.vectors.Vector4.m
+/// laddu.utils.vectors.Vec4.m
 ///
 #[pyclass(name = "Mass", module = "laddu")]
 #[derive(Clone, Serialize, Deserialize)]
@@ -159,7 +159,7 @@ impl PyMass {
 ///
 /// See Also
 /// --------
-/// laddu.utils.vectors.Vector3.costheta
+/// laddu.utils.vectors.Vec3.costheta
 ///
 #[pyclass(name = "CosTheta", module = "laddu")]
 #[derive(Clone, Serialize, Deserialize)]
@@ -264,7 +264,7 @@ impl PyCosTheta {
 ///
 /// See Also
 /// --------
-/// laddu.utils.vectors.Vector3.phi
+/// laddu.utils.vectors.Vec3.phi
 ///
 #[pyclass(name = "Phi", module = "laddu")]
 #[derive(Clone, Serialize, Deserialize)]
@@ -482,7 +482,7 @@ impl PyPolAngle {
 ///
 /// See Also
 /// --------
-/// laddu.utils.vectors.Vector3.mag
+/// laddu.utils.vectors.Vec3.mag
 ///
 #[pyclass(name = "PolMagnitude", module = "laddu")]
 #[derive(Clone, Serialize, Deserialize)]

--- a/crates/laddu-python/src/utils/vectors.rs
+++ b/crates/laddu-python/src/utils/vectors.rs
@@ -9,11 +9,11 @@ use pyo3::{exceptions::PyTypeError, prelude::*};
 /// px, py, pz : float
 ///     The Cartesian components of the 3-vector
 ///
-#[pyclass(name = "Vector3", module = "laddu")]
+#[pyclass(name = "Vec3", module = "laddu")]
 #[derive(Clone)]
-pub struct PyVector3(pub Vec3);
+pub struct PyVec3(pub Vec3);
 #[pymethods]
-impl PyVector3 {
+impl PyVec3 {
     #[new]
     fn new(px: Float, py: Float, pz: Float) -> Self {
         Self(Vec3::new(px, py, pz))
@@ -81,11 +81,11 @@ impl PyVector3 {
     fn __neg__(&self) -> PyResult<Self> {
         Ok(Self(-self.0))
     }
-    /// Calculate the dot product of two Vector3s.
+    /// Calculate the dot product of two Vec3s.
     ///
     /// Parameters
     /// ----------
-    /// other : Vector3
+    /// other : Vec3
     ///     A vector input with which the dot product is taken
     ///
     /// Returns
@@ -96,16 +96,16 @@ impl PyVector3 {
     pub fn dot(&self, other: Self) -> Float {
         self.0.dot(&other.0)
     }
-    /// Calculate the cross product of two Vector3s.
+    /// Calculate the cross product of two Vec3s.
     ///
     /// Parameters
     /// ----------
-    /// other : Vector3
+    /// other : Vec3
     ///     A vector input with which the cross product is taken
     ///
     /// Returns
     /// -------
-    /// Vector3
+    /// Vec3
     ///     The cross product of this vector and `other`
     ///
     fn cross(&self, other: Self) -> Self {
@@ -167,7 +167,7 @@ impl PyVector3 {
     ///
     /// See Also
     /// --------
-    /// Vector3.x
+    /// Vec3.x
     ///
     #[getter]
     fn px(&self) -> Float {
@@ -177,7 +177,7 @@ impl PyVector3 {
     ///
     /// See Also
     /// --------
-    /// Vector3.px
+    /// Vec3.px
     ///
     #[getter]
     fn x(&self) -> Float {
@@ -188,7 +188,7 @@ impl PyVector3 {
     ///
     /// See Also
     /// --------
-    /// Vector3.y
+    /// Vec3.y
     ///
     #[getter]
     fn py(&self) -> Float {
@@ -198,7 +198,7 @@ impl PyVector3 {
     ///
     /// See Also
     /// --------
-    /// Vector3.py
+    /// Vec3.py
     ///
     #[getter]
     fn y(&self) -> Float {
@@ -208,7 +208,7 @@ impl PyVector3 {
     ///
     /// See Also
     /// --------
-    /// Vector3.z
+    /// Vec3.z
     ///
     #[getter]
     fn pz(&self) -> Float {
@@ -218,7 +218,7 @@ impl PyVector3 {
     ///
     /// See Also
     /// --------
-    /// Vector3.pz
+    /// Vec3.pz
     ///
     #[getter]
     fn z(&self) -> Float {
@@ -237,11 +237,11 @@ impl PyVector3 {
     ///
     /// Returns
     /// -------
-    /// Vector4
+    /// Vec4
     ///     A new 4-momentum with the given mass
     ///
-    fn with_mass(&self, mass: Float) -> PyVector4 {
-        PyVector4(self.0.with_mass(mass))
+    fn with_mass(&self, mass: Float) -> PyVec4 {
+        PyVec4(self.0.with_mass(mass))
     }
     /// Convert a 3-vector momentum to a 4-momentum with the given energy.
     ///
@@ -252,18 +252,18 @@ impl PyVector3 {
     ///
     /// Returns
     /// -------
-    /// Vector4
+    /// Vec4
     ///     A new 4-momentum with the given energy
     ///
-    fn with_energy(&self, mass: Float) -> PyVector4 {
-        PyVector4(self.0.with_energy(mass))
+    fn with_energy(&self, mass: Float) -> PyVec4 {
+        PyVec4(self.0.with_energy(mass))
     }
     /// Convert the 3-vector to a ``numpy`` array.
     ///
     /// Returns
     /// -------
     /// numpy_vec: array_like
-    ///     A ``numpy`` array built from the components of this ``Vector3``
+    ///     A ``numpy`` array built from the components of this ``Vec3``
     ///
     fn to_numpy<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<Float>> {
         PyArray1::from_vec(py, self.0.into())
@@ -273,11 +273,11 @@ impl PyVector3 {
     /// Parameters
     /// ----------
     /// array_like
-    ///     An array containing the components of this ``Vector3``
+    ///     An array containing the components of this ``Vec3``
     ///
     /// Returns
     /// -------
-    /// laddu_vec: Vector3
+    /// laddu_vec: Vec3
     ///     A copy of the input array as a ``laddu`` vector
     ///
     #[staticmethod]
@@ -305,11 +305,11 @@ impl PyVector3 {
 ///     The energy component
 ///
 ///
-#[pyclass(name = "Vector4", module = "laddu")]
+#[pyclass(name = "Vec4", module = "laddu")]
 #[derive(Clone)]
-pub struct PyVector4(pub Vec4);
+pub struct PyVec4(pub Vec4);
 #[pymethods]
-impl PyVector4 {
+impl PyVec4 {
     #[new]
     fn new(px: Float, py: Float, pz: Float, e: Float) -> Self {
         Self(Vec4::new(px, py, pz, e))
@@ -383,7 +383,7 @@ impl PyVector4 {
     ///
     /// See Also
     /// --------
-    /// Vector4.m
+    /// Vec4.m
     ///
     #[getter]
     fn mag(&self) -> Float {
@@ -395,7 +395,7 @@ impl PyVector4 {
     ///
     /// See Also
     /// --------
-    /// Vector4.m2
+    /// Vec4.m2
     ///
     #[getter]
     fn mag2(&self) -> Float {
@@ -405,11 +405,11 @@ impl PyVector4 {
     ///
     /// See Also
     /// --------
-    /// Vector4.momentum
+    /// Vec4.momentum
     ///
     #[getter]
-    fn vec3(&self) -> PyVector3 {
-        PyVector3(self.0.vec3())
+    fn vec3(&self) -> PyVec3 {
+        PyVec3(self.0.vec3())
     }
     /// Boost the given 4-momentum according to a boost velocity.
     ///
@@ -420,20 +420,20 @@ impl PyVector4 {
     ///
     /// Parameters
     /// ----------
-    /// beta : Vector3
+    /// beta : Vec3
     ///     The relative velocity needed to get to the new frame from the current one
     ///
     /// Returns
     /// -------
-    /// Vector4
+    /// Vec4
     ///     The boosted 4-momentum
     ///
     /// See Also
     /// --------
-    /// Vector4.beta
-    /// Vector4.gamma
+    /// Vec4.beta
+    /// Vec4.gamma
     ///
-    fn boost(&self, beta: &PyVector3) -> Self {
+    fn boost(&self, beta: &PyVec3) -> Self {
         Self(self.0.boost(&beta.0))
     }
     /// The energy associated with this vector
@@ -488,8 +488,8 @@ impl PyVector4 {
     /// The 3-momentum part of this 4-momentum
     ///
     #[getter]
-    fn momentum(&self) -> PyVector3 {
-        PyVector3(self.0.momentum())
+    fn momentum(&self) -> PyVec3 {
+        PyVec3(self.0.momentum())
     }
     /// The relativistic gamma factor
     ///
@@ -497,8 +497,8 @@ impl PyVector4 {
     ///
     /// See Also
     /// --------
-    /// Vector4.beta
-    /// Vector4.boost
+    /// Vec4.beta
+    /// Vec4.boost
     ///
     #[getter]
     fn gamma(&self) -> Float {
@@ -510,12 +510,12 @@ impl PyVector4 {
     ///
     /// See Also
     /// --------
-    /// Vector4.gamma
-    /// Vector4.boost
+    /// Vec4.gamma
+    /// Vec4.boost
     ///
     #[getter]
-    fn beta(&self) -> PyVector3 {
-        PyVector3(self.0.beta())
+    fn beta(&self) -> PyVec3 {
+        PyVec3(self.0.beta())
     }
     /// The invariant mass associated with the four-momentum
     ///
@@ -523,7 +523,7 @@ impl PyVector4 {
     ///
     /// See Also
     /// --------
-    /// Vector4.mag
+    /// Vec4.mag
     ///
     #[getter]
     fn m(&self) -> Float {
@@ -535,7 +535,7 @@ impl PyVector4 {
     ///
     /// See Also
     /// --------
-    /// Vector4.mag2
+    /// Vec4.mag2
     ///
     #[getter]
     fn m2(&self) -> Float {
@@ -546,7 +546,7 @@ impl PyVector4 {
     /// Returns
     /// -------
     /// numpy_vec: array_like
-    ///     A ``numpy`` array built from the components of this ``Vector4``
+    ///     A ``numpy`` array built from the components of this ``Vec4``
     ///
     fn to_numpy<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<Float>> {
         PyArray1::from_vec(py, self.0.into())
@@ -556,11 +556,11 @@ impl PyVector4 {
     /// Parameters
     /// ----------
     /// array_like
-    ///     An array containing the components of this ``Vector4``
+    ///     An array containing the components of this ``Vec4``
     ///
     /// Returns
     /// -------
-    /// laddu_vec: Vector4
+    /// laddu_vec: Vec4
     ///     A copy of the input array as a ``laddu`` vector
     ///
     #[staticmethod]

--- a/py-laddu-mpi/pyproject.toml
+++ b/py-laddu-mpi/pyproject.toml
@@ -11,7 +11,15 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version", "license", "description", "readme"]
-dependencies = ["numpy", "docopt-ng", "pyarrow", "uproot", "fastparquet"]
+dependencies = [
+  "numpy",
+  "docopt-ng",
+  "pyarrow",
+  "uproot",
+  "fastparquet",
+  "pandas",
+  "polars",
+]
 
 [project.urls]
 Documentation = "https://laddu.readthedocs.io/en/stable/"

--- a/py-laddu/laddu/__init__.py
+++ b/py-laddu/laddu/__init__.py
@@ -41,7 +41,7 @@ from laddu.utils.variables import (
     Polarization,
     PolMagnitude,
 )
-from laddu.utils.vectors import Vector3, Vector4
+from laddu.utils.vectors import Vec3, Vec4
 
 __doc__: str = _laddu.__doc__
 __version__: str = _laddu.version()
@@ -78,8 +78,8 @@ __all__ = [
     'Polarization',
     'Scalar',
     'Status',
-    'Vector3',
-    'Vector4',
+    'Vec3',
+    'Vec4',
     'Ylm',
     'Zlm',
     '__version__',

--- a/py-laddu/laddu/__init__.pyi
+++ b/py-laddu/laddu/__init__.pyi
@@ -40,7 +40,7 @@ from laddu.utils.variables import (
     Polarization,
     PolMagnitude,
 )
-from laddu.utils.vectors import Vector3, Vector4
+from laddu.utils.vectors import Vec3, Vec4
 
 __version__: str
 
@@ -76,8 +76,8 @@ __all__ = [
     'Polarization',
     'Scalar',
     'Status',
-    'Vector3',
-    'Vector4',
+    'Vec3',
+    'Vec4',
     'Ylm',
     'Zlm',
     '__version__',

--- a/py-laddu/laddu/data.py
+++ b/py-laddu/laddu/data.py
@@ -1,15 +1,84 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from laddu.convert import read_root_file
-from laddu.laddu import BinnedDataset, Dataset, Event, open
+from laddu.laddu import BinnedDataset, DatasetBase, Event, open
 from laddu.utils.vectors import Vec3, Vec4
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pandas as pd
+    import polars as pl
+    import pyarrow as pa
+    from numpy.typing import NDArray
+
+
+class Dataset(DatasetBase):
+    P4_PREFIX: str = 'p4_'
+    AUX_PREFIX: str = 'aux_'
+
+    @staticmethod
+    def from_dict(
+        data: dict[str, Any], rest_frame_indices: list[int] | None = None
+    ) -> Dataset:
+        p4_count = len([key for key in data if key.startswith(Dataset.P4_PREFIX)]) // 4
+        aux_count = len([key for key in data if key.startswith(Dataset.AUX_PREFIX)]) // 3
+        events = []
+        n_events = len(data[f'{Dataset.P4_PREFIX}0_Px'])
+        weights = data.get('weight', np.ones(n_events))
+        for i in range(n_events):
+            p4s = [
+                Vec4.from_array(
+                    [
+                        data[f'{Dataset.P4_PREFIX}{j}_Px'][i],
+                        data[f'{Dataset.P4_PREFIX}{j}_Py'][i],
+                        data[f'{Dataset.P4_PREFIX}{j}_Pz'][i],
+                        data[f'{Dataset.P4_PREFIX}{j}_E'][i],
+                    ]
+                )
+                for j in range(p4_count)
+            ]
+            aux = [
+                Vec3.from_array(
+                    [
+                        data[f'{Dataset.AUX_PREFIX}{j}_x'][i],
+                        data[f'{Dataset.AUX_PREFIX}{j}_y'][i],
+                        data[f'{Dataset.AUX_PREFIX}{j}_z'][i],
+                    ]
+                )
+                for j in range(aux_count)
+            ]
+            weight = weights[i]
+            events.append(Event(p4s, aux, weight, rest_frame_indices=rest_frame_indices))
+        return DatasetBase(events)
+
+    @staticmethod
+    def from_numpy(
+        data: dict[str, NDArray[np.floating]], rest_frame_indices: list[int] | None = None
+    ) -> Dataset:
+        return Dataset.from_dict(data, rest_frame_indices=rest_frame_indices)
+
+    @staticmethod
+    def from_pandas(
+        data: pd.DataFrame, rest_frame_indices: list[int] | None = None
+    ) -> Dataset:
+        return Dataset.from_dict(data.to_dict(), rest_frame_indices=rest_frame_indices)
+
+    @staticmethod
+    def from_polars(
+        data: pl.DataFrame, rest_frame_indices: list[int] | None = None
+    ) -> Dataset:
+        return Dataset.from_dict(data.to_dict(), rest_frame_indices=rest_frame_indices)
+
+    @staticmethod
+    def from_arrow(
+        data: pa.Table, rest_frame_indices: list[int] | None = None
+    ) -> Dataset:
+        return Dataset.from_dict(data.to_pydict(), rest_frame_indices=rest_frame_indices)
 
 
 def open_amptools(
@@ -32,18 +101,18 @@ def open_amptools(
         num_entries=num_entries,
     )
     n_particles = len(p4s_list[0])
+    boost_indices = list(range(1, n_particles)) if boost_to_com else None
     ds = Dataset(
         [
             Event(
                 [Vec4.from_array(p4) for p4 in p4s],
                 [Vec3.from_array(eps_vec) for eps_vec in eps],
                 weight,
+                boost_indices=boost_indices,
             )
             for p4s, eps, weight in zip(p4s_list, eps_list, weight_list)
         ]
     )
-    if boost_to_com:
-        return ds.boost_to_rest_frame_of(list(range(1, n_particles)))  # skip the beam
     return ds
 
 

--- a/py-laddu/laddu/data.py
+++ b/py-laddu/laddu/data.py
@@ -25,6 +25,21 @@ class Dataset(DatasetBase):
     def from_dict(
         data: dict[str, Any], rest_frame_indices: list[int] | None = None
     ) -> Dataset:
+        """
+        Create a Dataset from a dict.
+
+        Arguments
+        ---------
+        data: dict of str to Any
+            dict of lists with keys matching the dataset format
+        rest_frame_indices: list of int, optional
+            If provided, the dataset will be boosted to the rest frame
+            of the 4-momenta specified by the indices
+
+        Returns
+        -------
+        Dataset
+        """
         p4_count = len([key for key in data if key.startswith(Dataset.P4_PREFIX)]) // 4
         aux_count = len([key for key in data if key.startswith(Dataset.AUX_PREFIX)]) // 3
         events = []
@@ -60,24 +75,84 @@ class Dataset(DatasetBase):
     def from_numpy(
         data: dict[str, NDArray[np.floating]], rest_frame_indices: list[int] | None = None
     ) -> Dataset:
+        """
+        Create a Dataset from a dict of numpy arrays.
+
+        Arguments
+        ---------
+        data: dict of str to NDArray
+            dict of arrays with keys matching the dataset format
+        rest_frame_indices: list of int, optional
+            If provided, the dataset will be boosted to the rest frame
+            of the 4-momenta specified by the indices
+
+        Returns
+        -------
+        Dataset
+        """
         return Dataset.from_dict(data, rest_frame_indices=rest_frame_indices)
 
     @staticmethod
     def from_pandas(
         data: pd.DataFrame, rest_frame_indices: list[int] | None = None
     ) -> Dataset:
+        """
+        Create a Dataset from a pandas DataFrame.
+
+        Arguments
+        ---------
+        data: pandas.DataFrame
+            DataFrame with columns matching the dataset format
+        rest_frame_indices: list of int, optional
+            If provided, the dataset will be boosted to the rest frame
+            of the 4-momenta specified by the indices
+
+        Returns
+        -------
+        Dataset
+        """
         return Dataset.from_dict(data.to_dict(), rest_frame_indices=rest_frame_indices)
 
     @staticmethod
     def from_polars(
         data: pl.DataFrame, rest_frame_indices: list[int] | None = None
     ) -> Dataset:
+        """
+        Create a Dataset from a polars DataFrame.
+
+        Arguments
+        ---------
+        data: polars.DataFrame
+            DataFrame with columns matching the dataset format
+        rest_frame_indices: list of int, optional
+            If provided, the dataset will be boosted to the rest frame
+            of the 4-momenta specified by the indices
+
+        Returns
+        -------
+        Dataset
+        """
         return Dataset.from_dict(data.to_dict(), rest_frame_indices=rest_frame_indices)
 
     @staticmethod
     def from_arrow(
         data: pa.Table, rest_frame_indices: list[int] | None = None
     ) -> Dataset:
+        """
+        Create a Dataset from a pyarrow Table.
+
+        Arguments
+        ---------
+        data: pyarrow.Table
+            Table with columns matching the dataset format
+        rest_frame_indices: list of int, optional
+            If provided, the dataset will be boosted to the rest frame
+            of the 4-momenta specified by the indices
+
+        Returns
+        -------
+        Dataset
+        """
         return Dataset.from_dict(data.to_pydict(), rest_frame_indices=rest_frame_indices)
 
 

--- a/py-laddu/laddu/data.py
+++ b/py-laddu/laddu/data.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from laddu.convert import read_root_file
 from laddu.laddu import BinnedDataset, Dataset, Event, open
-from laddu.utils.vectors import Vector3, Vector4
+from laddu.utils.vectors import Vec3, Vec4
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -35,8 +35,8 @@ def open_amptools(
     ds = Dataset(
         [
             Event(
-                [Vector4.from_array(p4) for p4 in p4s],
-                [Vector3.from_array(eps_vec) for eps_vec in eps],
+                [Vec4.from_array(p4) for p4 in p4s],
+                [Vec3.from_array(eps_vec) for eps_vec in eps],
                 weight,
             )
             for p4s, eps, weight in zip(p4s_list, eps_list, weight_list)

--- a/py-laddu/laddu/data.pyi
+++ b/py-laddu/laddu/data.pyi
@@ -1,7 +1,11 @@
 from pathlib import Path
+from typing import Any
 
 import numpy as np
-import numpy.typing as npt
+import pandas as pd
+import polars as pl
+import pyarrow as pa
+from numpy.typing import NDArray
 
 from laddu.utils.variables import CosTheta, Mandelstam, Mass, Phi, PolAngle, PolMagnitude
 from laddu.utils.vectors import Vec3, Vec4
@@ -14,13 +18,21 @@ def open_amptools(
     pol_angle: float | None = None,
     pol_magnitude: float | None = None,
     num_entries: int | None = None,
+    boost_to_com: bool = True,
 ) -> Dataset: ...
 
 class Event:
     p4s: list[Vec4]
-    eps: list[Vec3]
+    aux: list[Vec3]
     weight: float
-    def __init__(self, p4s: list[Vec4], eps: list[Vec3], weight: float) -> None: ...
+    def __init__(
+        self,
+        p4s: list[Vec4],
+        aux: list[Vec3],
+        weight: float,
+        *,
+        rest_frame_indices: list[int] | None = None,
+    ) -> None: ...
     def get_p4_sum(self, indices: list[int]) -> Vec4: ...
     def boost_to_rest_frame_of(self, indices: list[int]) -> Event: ...
 
@@ -28,7 +40,7 @@ class Dataset:
     events: list[Event]
     n_events: int
     n_events_weighted: float
-    weights: npt.NDArray[np.float64]
+    weights: NDArray[np.float64]
     def __init__(self, events: list[Event]) -> None: ...
     def __len__(self) -> int: ...
     def __add__(self, other: Dataset | int) -> Dataset: ...
@@ -42,12 +54,32 @@ class Dataset:
     ) -> BinnedDataset: ...
     def bootstrap(self, seed: int) -> Dataset: ...
     def boost_to_rest_frame_of(self, indices: list[int]) -> Dataset: ...
+    @staticmethod
+    def from_dict(
+        data: dict[str, Any], rest_frame_indices: list[int] | None = None
+    ) -> Dataset: ...
+    @staticmethod
+    def from_numpy(
+        data: dict[str, NDArray[np.floating]], rest_frame_indices: list[int] | None = None
+    ) -> Dataset: ...
+    @staticmethod
+    def from_pandas(
+        data: pd.DataFrame, rest_frame_indices: list[int] | None = None
+    ) -> Dataset: ...
+    @staticmethod
+    def from_polars(
+        data: pl.DataFrame, rest_frame_indices: list[int] | None = None
+    ) -> Dataset: ...
+    @staticmethod
+    def from_arrow(
+        data: pa.Table, rest_frame_indices: list[int] | None = None
+    ) -> Dataset: ...
 
 class BinnedDataset:
     n_bins: int
     range: tuple[float, float]
-    edges: npt.NDArray[np.float64]
+    edges: NDArray[np.float64]
     def __len__(self) -> int: ...
     def __getitem__(self, index: int) -> Dataset: ...
 
-def open(path: str) -> Dataset: ...
+def open(path: str | Path, *, rest_frame_indices: list[int] | None = None) -> Dataset: ...

--- a/py-laddu/laddu/data.pyi
+++ b/py-laddu/laddu/data.pyi
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 
 from laddu.utils.variables import CosTheta, Mandelstam, Mass, Phi, PolAngle, PolMagnitude
-from laddu.utils.vectors import Vector3, Vector4
+from laddu.utils.vectors import Vec3, Vec4
 
 def open_amptools(
     path: str | Path,
@@ -17,11 +17,11 @@ def open_amptools(
 ) -> Dataset: ...
 
 class Event:
-    p4s: list[Vector4]
-    eps: list[Vector3]
+    p4s: list[Vec4]
+    eps: list[Vec3]
     weight: float
-    def __init__(self, p4s: list[Vector4], eps: list[Vector3], weight: float) -> None: ...
-    def get_p4_sum(self, indices: list[int]) -> Vector4: ...
+    def __init__(self, p4s: list[Vec4], eps: list[Vec3], weight: float) -> None: ...
+    def get_p4_sum(self, indices: list[int]) -> Vec4: ...
     def boost_to_rest_frame_of(self, indices: list[int]) -> Event: ...
 
 class Dataset:

--- a/py-laddu/laddu/utils/vectors.py
+++ b/py-laddu/laddu/utils/vectors.py
@@ -1,3 +1,3 @@
-from laddu.laddu import Vector3, Vector4
+from laddu.laddu import Vec3, Vec4
 
-__all__ = ['Vector3', 'Vector4']
+__all__ = ['Vec3', 'Vec4']

--- a/py-laddu/laddu/utils/vectors.pyi
+++ b/py-laddu/laddu/utils/vectors.pyi
@@ -3,9 +3,9 @@ from typing import Sequence
 import numpy as np
 import numpy.typing as npt
 
-__all__ = ['Vector3', 'Vector4']
+__all__ = ['Vec3', 'Vec4']
 
-class Vector3:
+class Vec3:
     """A 3-momentum vector formed from Cartesian components.
 
     Parameters
@@ -31,7 +31,7 @@ class Vector3:
     costheta: float
     theta: float
     phi: float
-    unit: Vector3
+    unit: Vec3
     x: float
     y: float
     z: float
@@ -39,17 +39,17 @@ class Vector3:
     py: float
     pz: float
     def __init__(self, px: float, py: float, pz: float) -> None: ...
-    def __add__(self, other: Vector3 | int) -> Vector3: ...
-    def __radd__(self, other: Vector3 | int) -> Vector3: ...
-    def __sub__(self, other: Vector3 | int) -> Vector3: ...
-    def __rsub__(self, other: Vector3 | int) -> Vector3: ...
-    def __neg__(self) -> Vector3: ...
-    def dot(self, other: Vector3) -> float:
+    def __add__(self, other: Vec3 | int) -> Vec3: ...
+    def __radd__(self, other: Vec3 | int) -> Vec3: ...
+    def __sub__(self, other: Vec3 | int) -> Vec3: ...
+    def __rsub__(self, other: Vec3 | int) -> Vec3: ...
+    def __neg__(self) -> Vec3: ...
+    def dot(self, other: Vec3) -> float:
         """Calculate the dot product of two vectors.
 
         Parameters
         ----------
-        other : Vector3
+        other : Vec3
             A vector input with which the dot product is taken
 
         Returns
@@ -57,30 +57,30 @@ class Vector3:
         float
             The dot product of this vector and `other`
         """
-    def cross(self, other: Vector3) -> Vector3:
+    def cross(self, other: Vec3) -> Vec3:
         """
         Calculate the cross product of two vectors.
 
         Parameters
         ----------
-        other : Vector3
+        other : Vec3
             A vector input with which the cross product is taken
 
         Returns
         -------
-        Vector3
+        Vec3
             The cross product of this vector and `other`
         """
     def to_numpy(self) -> npt.NDArray[np.float64]: ...
     @staticmethod
-    def from_array(array: Sequence) -> Vector3: ...
-    def with_mass(self, mass: float) -> Vector4: ...
-    def with_energy(self, mass: float) -> Vector4: ...
+    def from_array(array: Sequence) -> Vec3: ...
+    def with_mass(self, mass: float) -> Vec4: ...
+    def with_energy(self, mass: float) -> Vec4: ...
 
-class Vector4:
+class Vec4:
     mag: float
     mag2: float
-    vec3: Vector3
+    vec3: Vec3
     t: float
     x: float
     y: float
@@ -89,17 +89,17 @@ class Vector4:
     px: float
     py: float
     pz: float
-    momentum: Vector3
+    momentum: Vec3
     gamma: float
-    beta: Vector3
+    beta: Vec3
     m: float
     m2: float
     def __init__(self, px: float, py: float, pz: float, e: float) -> None: ...
-    def __add__(self, other: Vector4) -> Vector4: ...
-    def __sub__(self, other: Vector4 | int) -> Vector4: ...
-    def __rsub__(self, other: Vector4 | int) -> Vector4: ...
-    def __neg__(self) -> Vector4: ...
-    def boost(self, beta: Vector3) -> Vector4: ...
+    def __add__(self, other: Vec4) -> Vec4: ...
+    def __sub__(self, other: Vec4 | int) -> Vec4: ...
+    def __rsub__(self, other: Vec4 | int) -> Vec4: ...
+    def __neg__(self) -> Vec4: ...
+    def boost(self, beta: Vec3) -> Vec4: ...
     def to_numpy(self) -> npt.NDArray[np.float64]: ...
     @staticmethod
-    def from_array(array: Sequence) -> Vector4: ...
+    def from_array(array: Sequence) -> Vec4: ...

--- a/py-laddu/pyproject.toml
+++ b/py-laddu/pyproject.toml
@@ -11,7 +11,15 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version", "license", "description", "readme"]
-dependencies = ["numpy", "docopt-ng", "pyarrow", "uproot", "fastparquet"]
+dependencies = [
+  "numpy",
+  "docopt-ng",
+  "pyarrow",
+  "uproot",
+  "fastparquet",
+  "pandas",
+  "polars",
+]
 
 [project.urls]
 Documentation = "https://laddu.readthedocs.io/en/stable/"

--- a/py-laddu/src/lib.rs
+++ b/py-laddu/src/lib.rs
@@ -23,7 +23,7 @@ mod laddu {
                 PyAngles, PyCosTheta, PyMandelstam, PyMass, PyPhi, PyPolAngle, PyPolMagnitude,
                 PyPolarization,
             },
-            vectors::{PyVector3, PyVector4},
+            vectors::{PyVec3, PyVec4},
         },
     };
 

--- a/py-laddu/tests/test_amplitudes.py
+++ b/py-laddu/tests/test_amplitudes.py
@@ -6,7 +6,7 @@ from laddu import (
     Event,
     Manager,
     Scalar,
-    Vector3,
+    Vec3,
     constant,
     parameter,
 )
@@ -16,12 +16,12 @@ from laddu.amplitudes import AmplitudeOne, AmplitudeZero, amplitude_product, amp
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 

--- a/py-laddu/tests/test_breit_wigner.py
+++ b/py-laddu/tests/test_breit_wigner.py
@@ -1,17 +1,17 @@
 import pytest
 
-from laddu import BreitWigner, Dataset, Event, Manager, Mass, Vector3, parameter
+from laddu import BreitWigner, Dataset, Event, Manager, Mass, Vec3, parameter
 
 
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 

--- a/py-laddu/tests/test_common.py
+++ b/py-laddu/tests/test_common.py
@@ -8,7 +8,7 @@ from laddu import (
     Manager,
     PolarComplexScalar,
     Scalar,
-    Vector3,
+    Vec3,
     parameter,
 )
 
@@ -16,12 +16,12 @@ from laddu import (
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 

--- a/py-laddu/tests/test_data.py
+++ b/py-laddu/tests/test_data.py
@@ -1,15 +1,15 @@
-from laddu import Dataset, Event, Mass, Vector3
+from laddu import Dataset, Event, Mass, Vec3
 
 
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 
@@ -78,12 +78,12 @@ def test_binned_dataset() -> None:
     dataset = Dataset(
         [
             Event(
-                [Vector3(0.0, 0.0, 1.0).with_mass(1.0)],
+                [Vec3(0.0, 0.0, 1.0).with_mass(1.0)],
                 [],
                 1.0,
             ),
             Event(
-                [Vector3(0.0, 0.0, 2.0).with_mass(2.0)],
+                [Vec3(0.0, 0.0, 2.0).with_mass(2.0)],
                 [],
                 2.0,
             ),

--- a/py-laddu/tests/test_kmatrix.py
+++ b/py-laddu/tests/test_kmatrix.py
@@ -1,6 +1,6 @@
 import pytest
 
-from laddu import Dataset, Event, Manager, Mass, Vector3, parameter
+from laddu import Dataset, Event, Manager, Mass, Vec3, parameter
 from laddu.amplitudes.kmatrix import (
     KopfKMatrixA0,
     KopfKMatrixA2,
@@ -14,12 +14,12 @@ from laddu.amplitudes.kmatrix import (
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 

--- a/py-laddu/tests/test_phase_space_factor.py
+++ b/py-laddu/tests/test_phase_space_factor.py
@@ -1,17 +1,17 @@
 import pytest
 
-from laddu import Dataset, Event, Manager, Mandelstam, Mass, PhaseSpaceFactor, Vector3
+from laddu import Dataset, Event, Manager, Mandelstam, Mass, PhaseSpaceFactor, Vec3
 
 
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 

--- a/py-laddu/tests/test_piecewise.py
+++ b/py-laddu/tests/test_piecewise.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from laddu import Dataset, Event, Manager, Mass, Vector3, parameter
+from laddu import Dataset, Event, Manager, Mass, Vec3, parameter
 from laddu.amplitudes.piecewise import (
     PiecewiseComplexScalar,
     PiecewisePolarComplexScalar,
@@ -12,12 +12,12 @@ from laddu.amplitudes.piecewise import (
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 

--- a/py-laddu/tests/test_serde.py
+++ b/py-laddu/tests/test_serde.py
@@ -2,7 +2,7 @@ import pickle
 
 import pytest
 
-from laddu import Dataset, Event, Manager, Mass, Scalar, Vector3, parameter
+from laddu import Dataset, Event, Manager, Mass, Scalar, Vec3, parameter
 from laddu.amplitudes.kmatrix import (
     KopfKMatrixF0,
     KopfKMatrixF2,
@@ -12,12 +12,12 @@ from laddu.amplitudes.kmatrix import (
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 

--- a/py-laddu/tests/test_variables.py
+++ b/py-laddu/tests/test_variables.py
@@ -11,19 +11,19 @@ from laddu import (
     PolAngle,
     Polarization,
     PolMagnitude,
-    Vector3,
+    Vec3,
 )
 
 
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 

--- a/py-laddu/tests/test_vectors.py
+++ b/py-laddu/tests/test_vectors.py
@@ -1,12 +1,12 @@
 import numpy as np
 import pytest
 
-from laddu import Vector3, Vector4
+from laddu import Vec3, Vec4
 
 
 def test_three_to_four_momentum_conversion() -> None:
-    p3 = Vector3(1.0, 2.0, 3.0)
-    target_p4 = Vector4(1.0, 2.0, 3.0, 10.0)
+    p3 = Vec3(1.0, 2.0, 3.0)
+    target_p4 = Vec4(1.0, 2.0, 3.0, 10.0)
     p4_from_mass = p3.with_mass(target_p4.m)
     assert target_p4.e == p4_from_mass.e
     assert target_p4.px == p4_from_mass.px
@@ -20,7 +20,7 @@ def test_three_to_four_momentum_conversion() -> None:
 
 
 def test_four_momentum_basics() -> None:
-    p = Vector4(3.0, 4.0, 5.0, 10.0)
+    p = Vec4(3.0, 4.0, 5.0, 10.0)
     assert p.e == 10.0
     assert p.px == 3.0
     assert p.py == 4.0
@@ -37,8 +37,8 @@ def test_four_momentum_basics() -> None:
 
 
 def test_three_momentum_basics() -> None:
-    p = Vector4(3.0, 4.0, 5.0, 10.0)
-    q = Vector4(1.2, -3.4, 7.6, 0.0)
+    p = Vec4(3.0, 4.0, 5.0, 10.0)
+    q = Vec4(1.2, -3.4, 7.6, 0.0)
     p3_view = p.momentum
     q3_view = q.momentum
     assert p3_view.px == 3.0
@@ -55,8 +55,8 @@ def test_three_momentum_basics() -> None:
     assert pytest.approx(p3_view.cross(q3_view).px) == 47.4
     assert pytest.approx(p3_view.cross(q3_view).py) == -16.8
     assert pytest.approx(p3_view.cross(q3_view).pz) == -15.0
-    p3 = Vector3(3.0, 4.0, 5.0)
-    q3 = Vector3(1.2, -3.4, 7.6)
+    p3 = Vec3(3.0, 4.0, 5.0)
+    q3 = Vec3(1.2, -3.4, 7.6)
     assert p3.px == 3.0
     assert p3.py == 4.0
     assert p3.pz == 5.0
@@ -74,7 +74,7 @@ def test_three_momentum_basics() -> None:
 
 
 def test_boost_com() -> None:
-    p = Vector4(3.0, 4.0, 5.0, 10.0)
+    p = Vec4(3.0, 4.0, 5.0, 10.0)
     zero = p.boost(-p.beta)
     assert zero.px == 0.0
     assert zero.py == 0.0
@@ -82,8 +82,8 @@ def test_boost_com() -> None:
 
 
 def test_boost() -> None:
-    p1 = Vector4(3.0, 4.0, 5.0, 10.0)
-    p2 = Vector4(3.4, 2.3, 1.2, 9.0)
+    p1 = Vec4(3.0, 4.0, 5.0, 10.0)
+    p2 = Vec4(3.4, 2.3, 1.2, 9.0)
     p1_boosted = p1.boost(-p2.beta)
     assert p1_boosted.e == 8.157632144622882
     assert p1_boosted.px == -0.6489200627053444

--- a/py-laddu/tests/test_ylm.py
+++ b/py-laddu/tests/test_ylm.py
@@ -1,17 +1,17 @@
 import pytest
 
-from laddu import Angles, Dataset, Event, Manager, Vector3, Ylm
+from laddu import Angles, Dataset, Event, Manager, Vec3, Ylm
 
 
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 

--- a/py-laddu/tests/test_zlm.py
+++ b/py-laddu/tests/test_zlm.py
@@ -1,17 +1,17 @@
 import pytest
 
-from laddu import Angles, Dataset, Event, Manager, Polarization, Vector3, Zlm
+from laddu import Angles, Dataset, Event, Manager, Polarization, Vec3, Zlm
 
 
 def make_test_event() -> Event:
     return Event(
         [
-            Vector3(0.0, 0.0, 8.747).with_mass(0.0),
-            Vector3(0.119, 0.374, 0.222).with_mass(1.007),
-            Vector3(-0.112, 0.293, 3.081).with_mass(0.498),
-            Vector3(-0.007, -0.667, 5.446).with_mass(0.498),
+            Vec3(0.0, 0.0, 8.747).with_mass(0.0),
+            Vec3(0.119, 0.374, 0.222).with_mass(1.007),
+            Vec3(-0.112, 0.293, 3.081).with_mass(0.498),
+            Vec3(-0.007, -0.667, 5.446).with_mass(0.498),
         ],
-        [Vector3(0.385, 0.022, 0.000)],
+        [Vec3(0.385, 0.022, 0.000)],
         0.48,
     )
 


### PR DESCRIPTION
# Quality of life update to `Dataset`s and `Event`s

* Resolves #57
* Adds `rest_frame_indices` argument to constructors of `Dataset` and `Event` as well as `open`
* Adds `open_boosted_to_rest_frame_of` convenience method to Rust API (not sure about the name, this might change someday)
* Adds `from_` methods for `dict`s of `list`s, `dict`s of `numpy` arrays, `polars`/`pandas` `DataFrame`s, and `pyarrow` `Table`s (right now these all just convert to the first method, but optimized methods can be written later)

Additionally, readthedocs/readthedocs.org/pull/12143 should now be in effect, resolving documentation issues.