### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.85.0"
 [workspace.dependencies]
 accurate = "0.4.1"
 approx = "0.5.1"
-arrow = "55.0.0"
+arrow = "55.1.0"
 auto_ops = "0.3.0"
 bincode = { version = "2.0.1", features = ["serde"] }
 criterion = { version = "2.10.1", package = "codspeed-criterion-compat", features = [
@@ -26,16 +26,16 @@ fastrand = "2.3.0"
 fastrand-contrib = "0.1.0"
 ganesh = "0.22.0"
 indexmap = { version = "2.9.0", features = ["serde"] }
-lazy_static = "1.4.0"
+lazy_static = "1.5.0"
 mpi = { version = "0.8.0", features = ["complex"] }
 nalgebra = "0.33.2"
 num = "0.4.3"
 num_cpus = { version = "1.16.0" }
-numpy = { version = "0.24.0", features = ["nalgebra"] }
+numpy = { version = "0.25.0", features = ["nalgebra"] }
 num-traits = "0.2.19"
-parquet = "55.0.0"
+parquet = "55.1.0"
 parking_lot = "0.12.3"
-pyo3 = { version = "0.24.1" }
+pyo3 = { version = "0.25.0" }
 rayon = { version = "1.10.0" }
 serde = "1.0.219"
 serde-pickle = "1.2.0"
@@ -44,10 +44,10 @@ shellexpand = "3.1.0"
 thiserror = "2.0.12"
 typetag = "0.2.20"
 
-laddu = { version = "0.6.3", path = "crates/laddu" }
-laddu-core = { version = "0.6.2", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.6.3", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.6.3", path = "crates/laddu-extensions" }
+laddu = { version = "0.7.0", path = "crates/laddu" }
+laddu-core = { version = "0.7.0", path = "crates/laddu-core" }
+laddu-amplitudes = { version = "0.7.0", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.7.0", path = "crates/laddu-extensions" }
 laddu-python = { version = "0.7.0", path = "crates/laddu-python" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.12"
 typetag = "0.2.20"
 
-laddu = { version = "0.6.2", path = "crates/laddu" }
-laddu-core = { version = "0.6.1", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.6.2", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.6.2", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.6.2", path = "crates/laddu-python" }
+laddu = { version = "0.6.3", path = "crates/laddu" }
+laddu-core = { version = "0.6.2", path = "crates/laddu-core" }
+laddu-amplitudes = { version = "0.6.3", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.6.3", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.7.0", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.6.2...laddu-amplitudes-v0.6.3) - 2025-05-20
+
+### Other
+
+- updated the following local packages: laddu-core, laddu-python
+
 ## [0.6.2](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.6.1...laddu-amplitudes-v0.6.2) - 2025-05-16
 
 ### Other

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.6.2"
+version = "0.6.3"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.6.3"
+version = "0.7.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-core/CHANGELOG.md
+++ b/crates/laddu-core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/denehoffman/laddu/compare/laddu-core-v0.6.1...laddu-core-v0.6.2) - 2025-05-20
+
+### Added
+
+- add method for opening a dataset boosted to the rest frame of the given p4 indices
+
+### Other
+
+- *(data)* fix boost tests
+
 ## [0.6.1](https://github.com/denehoffman/laddu/compare/laddu-core-v0.6.0...laddu-core-v0.6.1) - 2025-05-16
 
 ### Added

--- a/crates/laddu-core/Cargo.toml
+++ b/crates/laddu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-core"
-version = "0.6.2"
+version = "0.7.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-core/Cargo.toml
+++ b/crates/laddu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-core"
-version = "0.6.1"
+version = "0.6.2"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.6.2...laddu-extensions-v0.6.3) - 2025-05-20
+
+### Other
+
+- updated the following local packages: laddu-core, laddu-python
+
 ## [0.6.2](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.6.1...laddu-extensions-v0.6.2) - 2025-05-16
 
 ### Other

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.6.2"
+version = "0.6.3"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.6.3"
+version = "0.7.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.6.2...laddu-python-v0.7.0) - 2025-05-20
+
+### Added
+
+- improvements to `Dataset` conversions and opening methods
+
+### Fixed
+
+- update Python vector names (closes #57)
+
 ## [0.6.2](https://github.com/denehoffman/laddu/compare/laddu-python-v0.6.1...laddu-python-v0.6.2) - 2025-05-16
 
 ### Added

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.6.2"
+version = "0.7.0"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/denehoffman/laddu/compare/laddu-v0.6.2...laddu-v0.6.3) - 2025-05-20
+
+### Added
+
+- add method for opening a dataset boosted to the rest frame of the given p4 indices
+
+### Other
+
+- *(data)* fix boost tests
+
 ## [0.6.2](https://github.com/denehoffman/laddu/compare/laddu-v0.6.1...laddu-v0.6.2) - 2025-05-16
 
 ### Added

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.6.2"
+version = "0.6.3"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.6.3"
+version = "0.7.0"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.6.3...py-laddu-mpi-v0.6.4) - 2025-05-20
+
+### Added
+
+- improvements to `Dataset` conversions and opening methods
+- add method for opening a dataset boosted to the rest frame of the given p4 indices
+
+### Fixed
+
+- update Python vector names (closes #57)
+
+### Other
+
+- *(data)* fix boost tests
+- add documentation to new Dataset constructors
+
 ## [0.6.2](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.6.1...py-laddu-mpi-v0.6.2) - 2025-05-16
 
 ### Added

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.6.4"
+version = "0.7.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/denehoffman/laddu/compare/py-laddu-v0.6.3...py-laddu-v0.6.4) - 2025-05-20
+
+### Added
+
+- improvements to `Dataset` conversions and opening methods
+- add method for opening a dataset boosted to the rest frame of the given p4 indices
+
+### Fixed
+
+- update Python vector names (closes #57)
+
+### Other
+
+- add documentation to new Dataset constructors
+- *(data)* fix boost tests
+
 ## [0.6.2](https://github.com/denehoffman/laddu/compare/py-laddu-v0.6.1...py-laddu-v0.6.2) - 2025-05-16
 
 ### Added

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.6.4"
+version = "0.7.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu-core`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `laddu-python`: 0.6.2 -> 0.7.0 (⚠ API breaking changes)
* `laddu`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `py-laddu`: 0.6.3 -> 0.6.4
* `py-laddu-mpi`: 0.6.3 -> 0.6.4
* `laddu-amplitudes`: 0.6.2 -> 0.6.3
* `laddu-extensions`: 0.6.2 -> 0.6.3

### ⚠ `laddu-python` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_parameter_count_changed.ron

Failed in:
  laddu_python::data::py_open now takes 2 parameters instead of 1, in /tmp/.tmp1pP7wp/laddu/crates/laddu-python/src/data.rs:385

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct laddu_python::utils::vectors::PyVector3, previously in file /tmp/.tmpXmzxf3/laddu-python/src/utils/vectors.rs:14
  struct laddu_python::utils::vectors::PyVector4, previously in file /tmp/.tmpXmzxf3/laddu-python/src/utils/vectors.rs:310
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu-core`

<blockquote>

## [0.6.2](https://github.com/denehoffman/laddu/compare/laddu-core-v0.6.1...laddu-core-v0.6.2) - 2025-05-20

### Added

- add method for opening a dataset boosted to the rest frame of the given p4 indices

### Other

- *(data)* fix boost tests
</blockquote>

## `laddu-python`

<blockquote>

## [0.7.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.6.2...laddu-python-v0.7.0) - 2025-05-20

### Added

- improvements to `Dataset` conversions and opening methods

### Fixed

- update Python vector names (closes #57)
</blockquote>

## `laddu`

<blockquote>

## [0.6.3](https://github.com/denehoffman/laddu/compare/laddu-v0.6.2...laddu-v0.6.3) - 2025-05-20

### Added

- add method for opening a dataset boosted to the rest frame of the given p4 indices

### Other

- *(data)* fix boost tests
</blockquote>

## `py-laddu`

<blockquote>

## [0.6.4](https://github.com/denehoffman/laddu/compare/py-laddu-v0.6.3...py-laddu-v0.6.4) - 2025-05-20

### Added

- improvements to `Dataset` conversions and opening methods
- add method for opening a dataset boosted to the rest frame of the given p4 indices

### Fixed

- update Python vector names (closes #57)

### Other

- add documentation to new Dataset constructors
- *(data)* fix boost tests
</blockquote>

## `py-laddu-mpi`

<blockquote>

## [0.6.4](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.6.3...py-laddu-mpi-v0.6.4) - 2025-05-20

### Added

- improvements to `Dataset` conversions and opening methods
- add method for opening a dataset boosted to the rest frame of the given p4 indices

### Fixed

- update Python vector names (closes #57)

### Other

- *(data)* fix boost tests
- add documentation to new Dataset constructors
</blockquote>

## `laddu-amplitudes`

<blockquote>

## [0.6.3](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.6.2...laddu-amplitudes-v0.6.3) - 2025-05-20

### Other

- updated the following local packages: laddu-core, laddu-python
</blockquote>

## `laddu-extensions`

<blockquote>

## [0.6.3](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.6.2...laddu-extensions-v0.6.3) - 2025-05-20

### Other

- updated the following local packages: laddu-core, laddu-python
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).