### PR TITLE
Data indexing update

### DIFF
--- a/crates/laddu-core/src/data.rs
+++ b/crates/laddu-core/src/data.rs
@@ -101,6 +101,10 @@ impl Event {
             weight: self.weight,
         }
     }
+    /// Evaluate a [`Variable`] on an [`Event`].
+    pub fn evaluate<V: Variable>(&self, variable: &V) -> Float {
+        variable.value(self)
+    }
 }
 
 /// A collection of [`Event`]s.
@@ -571,6 +575,10 @@ impl Dataset {
             })
         }
     }
+    /// Evaluate a [`Variable`] on every event in the [`Dataset`].
+    pub fn evaluate<V: Variable>(&self, variable: &V) -> Vec<Float> {
+        variable.value_on(self)
+    }
 }
 
 impl_op_ex!(+ |a: &Dataset, b: &Dataset| ->  Dataset { Dataset { events: a.events.iter().chain(b.events.iter()).cloned().collect() }});
@@ -805,6 +813,8 @@ impl BinnedDataset {
 
 #[cfg(test)]
 mod tests {
+    use crate::Mass;
+
     use super::*;
     use approx::{assert_relative_eq, assert_relative_ne};
     use serde::{Deserialize, Serialize};
@@ -834,6 +844,13 @@ mod tests {
         assert_relative_eq!(p4_sum.px(), 0.0, epsilon = Float::EPSILON.sqrt());
         assert_relative_eq!(p4_sum.py(), 0.0, epsilon = Float::EPSILON.sqrt());
         assert_relative_eq!(p4_sum.pz(), 0.0, epsilon = Float::EPSILON.sqrt());
+    }
+
+    #[test]
+    fn test_event_evaluate() {
+        let event = test_event();
+        let mass = Mass::new([1]);
+        assert_relative_eq!(event.evaluate(&mass), 1.007);
     }
 
     #[test]
@@ -898,6 +915,13 @@ mod tests {
         assert_relative_eq!(p4_sum.px(), 0.0, epsilon = Float::EPSILON.sqrt());
         assert_relative_eq!(p4_sum.py(), 0.0, epsilon = Float::EPSILON.sqrt());
         assert_relative_eq!(p4_sum.pz(), 0.0, epsilon = Float::EPSILON.sqrt());
+    }
+
+    #[test]
+    fn test_dataset_evaluate() {
+        let dataset = test_dataset();
+        let mass = Mass::new([1]);
+        assert_relative_eq!(dataset.evaluate(&mass)[0], 1.007);
     }
 
     #[test]

--- a/crates/laddu-core/src/utils/variables.rs
+++ b/crates/laddu-core/src/utils/variables.rs
@@ -805,7 +805,7 @@ mod tests {
 
     #[test]
     fn test_variable_value_on() {
-        let dataset = Arc::new(test_dataset());
+        let dataset = test_dataset();
         let mass = Mass::new(vec![2, 3]);
 
         let values = mass.value_on(&dataset);

--- a/crates/laddu-core/src/utils/variables.rs
+++ b/crates/laddu-core/src/utils/variables.rs
@@ -1,9 +1,6 @@
 use dyn_clone::DynClone;
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{Debug, Display},
-    sync::Arc,
-};
+use std::fmt::{Debug, Display};
 
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
@@ -34,7 +31,7 @@ pub trait Variable: DynClone + Send + Sync + Debug + Display {
     ///
     /// This method is not intended to be called in analyses but rather in writing methods
     /// that have `mpi`-feature-gated versions. Most users should just call [`Variable::value_on`] instead.
-    fn value_on_local(&self, dataset: &Arc<Dataset>) -> Vec<Float> {
+    fn value_on_local(&self, dataset: &Dataset) -> Vec<Float> {
         #[cfg(feature = "rayon")]
         let local_values: Vec<Float> = dataset.events.par_iter().map(|e| self.value(e)).collect();
         #[cfg(not(feature = "rayon"))]
@@ -50,7 +47,7 @@ pub trait Variable: DynClone + Send + Sync + Debug + Display {
     /// This method is not intended to be called in analyses but rather in writing methods
     /// that have `mpi`-feature-gated versions. Most users should just call [`Variable::value_on`] instead.
     #[cfg(feature = "mpi")]
-    fn value_on_mpi(&self, dataset: &Arc<Dataset>, world: &SimpleCommunicator) -> Vec<Float> {
+    fn value_on_mpi(&self, dataset: &Dataset, world: &SimpleCommunicator) -> Vec<Float> {
         let local_weights = self.value_on_local(dataset);
         let n_events = dataset.n_events();
         let mut buffer: Vec<Float> = vec![0.0; n_events];
@@ -64,7 +61,7 @@ pub trait Variable: DynClone + Send + Sync + Debug + Display {
 
     /// This method distributes the [`Variable::value`] method over each [`Event`] in a
     /// [`Dataset`].
-    fn value_on(&self, dataset: &Arc<Dataset>) -> Vec<Float> {
+    fn value_on(&self, dataset: &Dataset) -> Vec<Float> {
         #[cfg(feature = "mpi")]
         {
             if let Some(world) = crate::mpi::get_world() {
@@ -577,6 +574,7 @@ impl Variable for Mandelstam {
 #[cfg(test)]
 mod tests {
     use approx::assert_relative_eq;
+    use std::sync::Arc;
 
     use crate::data::{test_dataset, test_event};
 

--- a/crates/laddu-python/src/utils/variables.rs
+++ b/crates/laddu-python/src/utils/variables.rs
@@ -10,10 +10,7 @@ use laddu_core::{
 use numpy::PyArray1;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{Debug, Display},
-    sync::Arc,
-};
+use std::fmt::{Debug, Display};
 
 #[derive(FromPyObject, Clone, Serialize, Deserialize)]
 pub enum PyVariable {
@@ -683,7 +680,7 @@ impl PyMandelstam {
 
 #[typetag::serde]
 impl Variable for PyVariable {
-    fn value_on(&self, dataset: &Arc<Dataset>) -> Vec<Float> {
+    fn value_on(&self, dataset: &Dataset) -> Vec<Float> {
         match self {
             PyVariable::Mass(mass) => mass.0.value_on(dataset),
             PyVariable::CosTheta(cos_theta) => cos_theta.0.value_on(dataset),

--- a/py-laddu/laddu/data.pyi
+++ b/py-laddu/laddu/data.pyi
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, overload
 
 import numpy as np
 import pandas as pd
@@ -35,6 +35,9 @@ class Event:
     ) -> None: ...
     def get_p4_sum(self, indices: list[int]) -> Vec4: ...
     def boost_to_rest_frame_of(self, indices: list[int]) -> Event: ...
+    def evaluate(
+        self, variable: Mass | CosTheta | Phi | PolAngle | PolMagnitude | Mandelstam
+    ) -> float: ...
 
 class Dataset:
     events: list[Event]
@@ -45,7 +48,15 @@ class Dataset:
     def __len__(self) -> int: ...
     def __add__(self, other: Dataset | int) -> Dataset: ...
     def __radd__(self, other: Dataset | int) -> Dataset: ...
+    @overload
     def __getitem__(self, index: int) -> Event: ...
+    @overload
+    def __getitem__(
+        self, index: Mass | CosTheta | Phi | PolAngle | PolMagnitude | Mandelstam
+    ) -> NDArray[np.float64]: ...
+    def __getitem__(
+        self, index: int | Mass | CosTheta | Phi | PolAngle | PolMagnitude | Mandelstam
+    ) -> Event | NDArray[np.float64]: ...
     def bin_by(
         self,
         variable: Mass | CosTheta | Phi | PolAngle | PolMagnitude | Mandelstam,
@@ -74,6 +85,9 @@ class Dataset:
     def from_arrow(
         data: pa.Table, rest_frame_indices: list[int] | None = None
     ) -> Dataset: ...
+    def evaluate(
+        self, variable: Mass | CosTheta | Phi | PolAngle | PolMagnitude | Mandelstam
+    ) -> NDArray[np.float64]: ...
 
 class BinnedDataset:
     n_bins: int

--- a/py-laddu/tests/test_data.py
+++ b/py-laddu/tests/test_data.py
@@ -40,6 +40,21 @@ def test_event_p4_sum() -> None:
     assert p4_sum.e == event.p4s[2].e + event.p4s[3].e
 
 
+def test_event_boost() -> None:
+    event = make_test_event()
+    event_boosted = event.boost_to_rest_frame_of([1, 2, 3])
+    p4_sum = event_boosted.get_p4_sum([1, 2, 3])
+    assert pytest.approx(p4_sum.px) == 0.0
+    assert pytest.approx(p4_sum.py) == 0.0
+    assert pytest.approx(p4_sum.pz) == 0.0
+
+
+def test_event_evaluate() -> None:
+    event = make_test_event()
+    mass = Mass([1])
+    assert event.evaluate(mass) == 1.007
+
+
 def test_dataset_conversion() -> None:
     data = {
         'p4_0_Px': [1.0, 2.0, 3.0, 4.0],
@@ -106,6 +121,19 @@ def test_dataset_sum() -> None:
 
 
 # TODO: Dataset::filter requires free-threading or some other workaround (or maybe we make a non-parallel method)
+
+
+def test_dataset_evaluate() -> None:
+    dataset = make_test_dataset()
+    mass = Mass([1])
+    assert dataset.evaluate(mass)[0] == 1.007
+
+
+def test_dataset_index() -> None:
+    dataset = make_test_dataset()
+    assert isinstance(dataset[0], Event)
+    mass = Mass([1])
+    assert isinstance(dataset[mass], np.ndarray)
 
 
 def test_binned_dataset() -> None:


### PR DESCRIPTION
This update adds some nice syntax for working with `Variable`s, `Event`s, and `Dataset`s.

* New methods (along with equivalent Python methods):
  * `Event::evaluate(&Variable) -> Float`
  * `Dataset::evaluate(&Variable) -> Vec<Float>`
* Python-only:
  * `Dataset[Variable] -> NDArray[np.float64]`

This update also contains a breaking change, switching the argument of `Variable` trait methods to use `&Dataset` instead of `&Arc<Dataset>`. Turns out this was not required at all and the switch makes it easier to use.