### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ typetag = "0.2.20"
 
 laddu = { version = "0.8.0", path = "crates/laddu" }
 laddu-core = { version = "0.8.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.7.2", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.7.2", path = "crates/laddu-extensions" }
+laddu-amplitudes = { version = "0.8.0", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.8.0", path = "crates/laddu-extensions" }
 laddu-python = { version = "0.8.0", path = "crates/laddu-python" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ shellexpand = "3.1.0"
 thiserror = "2.0.12"
 typetag = "0.2.20"
 
-laddu = { version = "0.7.1", path = "crates/laddu" }
-laddu-core = { version = "0.7.1", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.7.1", path = "crates/laddu-amplitudes" }
-laddu-extensions = { version = "0.7.1", path = "crates/laddu-extensions" }
-laddu-python = { version = "0.7.1", path = "crates/laddu-python" }
+laddu = { version = "0.8.0", path = "crates/laddu" }
+laddu-core = { version = "0.8.0", path = "crates/laddu-core" }
+laddu-amplitudes = { version = "0.7.2", path = "crates/laddu-amplitudes" }
+laddu-extensions = { version = "0.7.2", path = "crates/laddu-extensions" }
+laddu-python = { version = "0.8.0", path = "crates/laddu-python" }
 
 [profile.release]
 lto = "thin"

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.7.1...laddu-amplitudes-v0.7.2) - 2025-06-17
+
+### Other
+
+- updated the following local packages: laddu-core, laddu-python
+
 ## [0.7.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.7.0...laddu-amplitudes-v0.7.1) - 2025-05-30
 
 ### Other

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.7.1"
+version = "0.7.2"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.7.2"
+version = "0.8.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-core/CHANGELOG.md
+++ b/crates/laddu-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.7.1...laddu-core-v0.8.0) - 2025-06-17
+
+### Added
+
+- add `evaluate(Variable)` method to `Dataset` and `Event`
+
+### Other
+
+- update test to get rid of `Arc<Dataset>` structure
+- [**breaking**] change `Variable` trait methods to operate on `&Dataset` rather than `&Arc<Dataset>`
+
 ## [0.7.1](https://github.com/denehoffman/laddu/compare/laddu-core-v0.7.0...laddu-core-v0.7.1) - 2025-05-30
 
 ### Added

--- a/crates/laddu-core/Cargo.toml
+++ b/crates/laddu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-core"
-version = "0.7.1"
+version = "0.8.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/CHANGELOG.md
+++ b/crates/laddu-extensions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.7.1...laddu-extensions-v0.7.2) - 2025-06-17
+
+### Other
+
+- updated the following local packages: laddu-core, laddu-python
+
 ## [0.7.1](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.7.0...laddu-extensions-v0.7.1) - 2025-05-30
 
 ### Other

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.7.2"
+version = "0.8.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-extensions/Cargo.toml
+++ b/crates/laddu-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-extensions"
-version = "0.7.1"
+version = "0.7.2"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu-python/CHANGELOG.md
+++ b/crates/laddu-python/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.7.1...laddu-python-v0.8.0) - 2025-06-17
+
+### Added
+
+- add `evaluate(Variable)` method to `Dataset` and `Event`
+
+### Other
+
+- [**breaking**] change `Variable` trait methods to operate on `&Dataset` rather than `&Arc<Dataset>`
+
 ## [0.7.1](https://github.com/denehoffman/laddu/compare/laddu-python-v0.7.0...laddu-python-v0.7.1) - 2025-05-30
 
 ### Other

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-python"
-version = "0.7.1"
+version = "0.8.0"
 description = "Amplitude analysis made short and sweet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/denehoffman/laddu/compare/laddu-v0.7.1...laddu-v0.8.0) - 2025-06-17
+
+### Added
+
+- add `evaluate(Variable)` method to `Dataset` and `Event`
+
+### Other
+
+- update test to get rid of `Arc<Dataset>` structure
+- [**breaking**] change `Variable` trait methods to operate on `&Dataset` rather than `&Arc<Dataset>`
+
 ## [0.7.1](https://github.com/denehoffman/laddu/compare/laddu-v0.7.0...laddu-v0.7.1) - 2025-05-30
 
 ### Added

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.7.1"
+version = "0.8.0"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.7.1...py-laddu-mpi-v0.8.0) - 2025-06-17
+
+### Added
+
+- add `evaluate(Variable)` method to `Dataset` and `Event`
+
+### Other
+
+- update test to get rid of `Arc<Dataset>` structure
+- [**breaking**] change `Variable` trait methods to operate on `&Dataset` rather than `&Arc<Dataset>`
+
 ## [0.7.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.7.0...py-laddu-mpi-v0.7.1) - 2025-05-30
 
 ### Added

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/denehoffman/laddu/compare/py-laddu-v0.7.1...py-laddu-v0.8.0) - 2025-06-17
+
+### Added
+
+- add `evaluate(Variable)` method to `Dataset` and `Event`
+
+### Other
+
+- update test to get rid of `Arc<Dataset>` structure
+- [**breaking**] change `Variable` trait methods to operate on `&Dataset` rather than `&Arc<Dataset>`
+
 ## [0.7.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.7.0...py-laddu-v0.7.1) - 2025-05-30
 
 ### Added

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu-core`: 0.7.1 -> 0.8.0 (✓ API compatible changes)
* `laddu-python`: 0.7.1 -> 0.8.0 (✓ API compatible changes)
* `laddu`: 0.7.1 -> 0.8.0 (✓ API compatible changes)
* `py-laddu`: 0.7.1 -> 0.8.0
* `py-laddu-mpi`: 0.7.1 -> 0.8.0
* `laddu-amplitudes`: 0.7.1 -> 0.7.2
* `laddu-extensions`: 0.7.1 -> 0.7.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu-core`

<blockquote>

## [0.8.0](https://github.com/denehoffman/laddu/compare/laddu-core-v0.7.1...laddu-core-v0.8.0) - 2025-06-17

### Added

- add `evaluate(Variable)` method to `Dataset` and `Event`

### Other

- update test to get rid of `Arc<Dataset>` structure
- [**breaking**] change `Variable` trait methods to operate on `&Dataset` rather than `&Arc<Dataset>`
</blockquote>

## `laddu-python`

<blockquote>

## [0.8.0](https://github.com/denehoffman/laddu/compare/laddu-python-v0.7.1...laddu-python-v0.8.0) - 2025-06-17

### Added

- add `evaluate(Variable)` method to `Dataset` and `Event`

### Other

- [**breaking**] change `Variable` trait methods to operate on `&Dataset` rather than `&Arc<Dataset>`
</blockquote>

## `laddu`

<blockquote>

## [0.8.0](https://github.com/denehoffman/laddu/compare/laddu-v0.7.1...laddu-v0.8.0) - 2025-06-17

### Added

- add `evaluate(Variable)` method to `Dataset` and `Event`

### Other

- update test to get rid of `Arc<Dataset>` structure
- [**breaking**] change `Variable` trait methods to operate on `&Dataset` rather than `&Arc<Dataset>`
</blockquote>

## `py-laddu`

<blockquote>

## [0.8.0](https://github.com/denehoffman/laddu/compare/py-laddu-v0.7.1...py-laddu-v0.8.0) - 2025-06-17

### Added

- add `evaluate(Variable)` method to `Dataset` and `Event`

### Other

- update test to get rid of `Arc<Dataset>` structure
- [**breaking**] change `Variable` trait methods to operate on `&Dataset` rather than `&Arc<Dataset>`
</blockquote>

## `py-laddu-mpi`

<blockquote>

## [0.8.0](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.7.1...py-laddu-mpi-v0.8.0) - 2025-06-17

### Added

- add `evaluate(Variable)` method to `Dataset` and `Event`

### Other

- update test to get rid of `Arc<Dataset>` structure
- [**breaking**] change `Variable` trait methods to operate on `&Dataset` rather than `&Arc<Dataset>`
</blockquote>

## `laddu-amplitudes`

<blockquote>

## [0.7.2](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.7.1...laddu-amplitudes-v0.7.2) - 2025-06-17

### Other

- updated the following local packages: laddu-core, laddu-python
</blockquote>

## `laddu-extensions`

<blockquote>

## [0.7.2](https://github.com/denehoffman/laddu/compare/laddu-extensions-v0.7.1...laddu-extensions-v0.7.2) - 2025-06-17

### Other

- updated the following local packages: laddu-core, laddu-python
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).