### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ shellexpand = "3.1.0"
 thiserror = "2.0.12"
 typetag = "0.2.20"
 
-laddu = { version = "0.9.0", path = "crates/laddu" }
+laddu = { version = "0.9.1", path = "crates/laddu" }
 laddu-core = { version = "0.9.0", path = "crates/laddu-core" }
-laddu-amplitudes = { version = "0.9.0", path = "crates/laddu-amplitudes" }
+laddu-amplitudes = { version = "0.10.0", path = "crates/laddu-amplitudes" }
 laddu-extensions = { version = "0.9.0", path = "crates/laddu-extensions" }
 laddu-python = { version = "0.9.0", path = "crates/laddu-python" }
 

--- a/crates/laddu-amplitudes/CHANGELOG.md
+++ b/crates/laddu-amplitudes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.9.0...laddu-amplitudes-v0.10.0) - 2025-07-23
+
+### Other
+
+- K-Matrix Covariance ([#81](https://github.com/denehoffman/laddu/pull/81))
+
 ## [0.8.1](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.8.0...laddu-amplitudes-v0.8.1) - 2025-06-20
 
 ### Added

--- a/crates/laddu-amplitudes/Cargo.toml
+++ b/crates/laddu-amplitudes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu-amplitudes"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/laddu/CHANGELOG.md
+++ b/crates/laddu/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/denehoffman/laddu/compare/laddu-v0.9.0...laddu-v0.9.1) - 2025-07-23
+
+### Other
+
+- K-Matrix Covariance ([#81](https://github.com/denehoffman/laddu/pull/81))
+
 ## [0.8.1](https://github.com/denehoffman/laddu/compare/laddu-v0.8.0...laddu-v0.8.1) - 2025-06-20
 
 ### Added

--- a/crates/laddu/Cargo.toml
+++ b/crates/laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laddu"
-version = "0.9.0"
+version = "0.9.1"
 description = "Amplitude analysis made short and sweet"
 documentation = "https://docs.rs/laddu"
 edition.workspace = true

--- a/py-laddu-mpi/CHANGELOG.md
+++ b/py-laddu-mpi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.9.0...py-laddu-mpi-v0.9.1) - 2025-07-23
+
+### Other
+
+- K-Matrix Covariance ([#81](https://github.com/denehoffman/laddu/pull/81))
+
 ## [0.8.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.8.0...py-laddu-mpi-v0.8.1) - 2025-06-20
 
 ### Added

--- a/py-laddu-mpi/Cargo.toml
+++ b/py-laddu-mpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu-mpi"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true

--- a/py-laddu/CHANGELOG.md
+++ b/py-laddu/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.9.0...py-laddu-v0.9.1) - 2025-07-23
+
+### Other
+
+- K-Matrix Covariance ([#81](https://github.com/denehoffman/laddu/pull/81))
+
 ## [0.8.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.8.0...py-laddu-v0.8.1) - 2025-06-20
 
 ### Added

--- a/py-laddu/Cargo.toml
+++ b/py-laddu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-laddu"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `laddu-amplitudes`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `laddu`: 0.9.0 -> 0.9.1 (✓ API compatible changes)
* `py-laddu`: 0.9.0 -> 0.9.1
* `py-laddu-mpi`: 0.9.0 -> 0.9.1

### ⚠ `laddu-amplitudes` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_parameter_count_changed.ron

Failed in:
  laddu_amplitudes::kmatrix::py_kopf_kmatrix_f0 now takes 5 parameters instead of 4, in /tmp/.tmpJT2HwR/laddu/crates/laddu-amplitudes/src/kmatrix/f0.rs:299
  laddu_amplitudes::kmatrix::py_kopf_kmatrix_a2 now takes 5 parameters instead of 4, in /tmp/.tmpJT2HwR/laddu/crates/laddu-amplitudes/src/kmatrix/a2.rs:233
  laddu_amplitudes::kmatrix::py_kopf_kmatrix_f2 now takes 5 parameters instead of 4, in /tmp/.tmpJT2HwR/laddu/crates/laddu-amplitudes/src/kmatrix/f2.rs:265
  laddu_amplitudes::kmatrix::py_kopf_kmatrix_a0 now takes 5 parameters instead of 4, in /tmp/.tmpJT2HwR/laddu/crates/laddu-amplitudes/src/kmatrix/a0.rs:220

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  laddu_amplitudes::kmatrix::KopfKMatrixA2::new now takes 5 parameters instead of 4, in /tmp/.tmpJT2HwR/laddu/crates/laddu-amplitudes/src/kmatrix/a2.rs:88
  laddu_amplitudes::kmatrix::KopfKMatrixF2::new now takes 5 parameters instead of 4, in /tmp/.tmpJT2HwR/laddu/crates/laddu-amplitudes/src/kmatrix/f2.rs:114
  laddu_amplitudes::kmatrix::KopfKMatrixA0::new now takes 5 parameters instead of 4, in /tmp/.tmpJT2HwR/laddu/crates/laddu-amplitudes/src/kmatrix/a0.rs:77
  laddu_amplitudes::kmatrix::KopfKMatrixF0::new now takes 5 parameters instead of 4, in /tmp/.tmpJT2HwR/laddu/crates/laddu-amplitudes/src/kmatrix/f0.rs:139
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `laddu-amplitudes`

<blockquote>

## [0.10.0](https://github.com/denehoffman/laddu/compare/laddu-amplitudes-v0.9.0...laddu-amplitudes-v0.10.0) - 2025-07-23

### Other

- K-Matrix Covariance ([#81](https://github.com/denehoffman/laddu/pull/81))
</blockquote>

## `laddu`

<blockquote>

## [0.9.1](https://github.com/denehoffman/laddu/compare/laddu-v0.9.0...laddu-v0.9.1) - 2025-07-23

### Other

- K-Matrix Covariance ([#81](https://github.com/denehoffman/laddu/pull/81))
</blockquote>

## `py-laddu`

<blockquote>

## [0.9.1](https://github.com/denehoffman/laddu/compare/py-laddu-v0.9.0...py-laddu-v0.9.1) - 2025-07-23

### Other

- K-Matrix Covariance ([#81](https://github.com/denehoffman/laddu/pull/81))
</blockquote>

## `py-laddu-mpi`

<blockquote>

## [0.9.1](https://github.com/denehoffman/laddu/compare/py-laddu-mpi-v0.9.0...py-laddu-mpi-v0.9.1) - 2025-07-23

### Other

- K-Matrix Covariance ([#81](https://github.com/denehoffman/laddu/pull/81))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).