### PR TITLE
Production Vertex Terms and Rejection Sampling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ errorfunctions = "0.2.0"
 factorial = "0.4.0"
 fastrand = "2.3.0"
 fastrand-contrib = "0.1.0"
-ganesh = "0.27.0"
+ganesh = "0.27.1"
 indexmap = { version = "2.13.0", features = ["serde"] }
 lazy_static = "1.5.0"
 mpi = { version = "0.8.1", features = ["complex"] }

--- a/crates/laddu-amplitudes/src/angular.rs
+++ b/crates/laddu-amplitudes/src/angular.rs
@@ -12,4 +12,4 @@ pub use barrier::BlattWeisskopf;
 pub use constants::{ClebschGordan, Wigner3j};
 pub use harmonics::{PolPhase, Ylm, Zlm};
 pub use sdme::{PhotonHelicity, PhotonPolarization, PhotonSDME};
-pub use wigner::{DecayAmplitudeExt, WignerD};
+pub use wigner::{DecayAmplitudeExt, ProductionAmplitudeExt, WignerD};

--- a/crates/laddu-amplitudes/src/angular/wigner.rs
+++ b/crates/laddu-amplitudes/src/angular/wigner.rs
@@ -7,7 +7,8 @@ use laddu_core::{
     resources::{Cache, ComplexScalarID, Parameters, Resources},
     traits::Variable,
     variables::Angles,
-    AngularMomentum, Decay, Frame, LadduResult, OrbitalAngularMomentum, Projection, SpinState,
+    AngularMomentum, Decay, Frame, LadduResult, OrbitalAngularMomentum, Production, Projection,
+    SpinState,
 };
 use nalgebra::DVector;
 use num::complex::Complex64;
@@ -143,6 +144,99 @@ impl DecayAmplitudeExt for Decay {
                 )?
                 * self
                     .helicity_factor(tags, spin, projection, daughter, lambda_1, lambda_2, frame)?,
+        )
+    }
+}
+
+/// Extension methods that build production-local angular expressions from [`Production`] objects.
+pub trait ProductionAmplitudeExt {
+    /// Construct the helicity-basis angular factor for one explicit helicity term.
+    #[allow(clippy::too_many_arguments)]
+    fn helicity_factor(
+        &self,
+        tags: impl IntoTags,
+        spin: AngularMomentum,
+        projection: Projection,
+        lambda_produced: Projection,
+        lambda_recoil: Projection,
+        frame: Frame,
+    ) -> LadduResult<Expression>;
+
+    /// Construct the canonical-basis spin-angular factor for one explicit LS/helicity term.
+    #[allow(clippy::too_many_arguments)]
+    fn canonical_factor(
+        &self,
+        tags: impl IntoTags,
+        spin: AngularMomentum,
+        projection: Projection,
+        orbital_l: OrbitalAngularMomentum,
+        coupled_spin: AngularMomentum,
+        produced_spin: AngularMomentum,
+        recoil_spin: AngularMomentum,
+        lambda_produced: Projection,
+        lambda_recoil: Projection,
+        frame: Frame,
+    ) -> LadduResult<Expression>;
+}
+
+impl ProductionAmplitudeExt for Production {
+    fn helicity_factor(
+        &self,
+        tags: impl IntoTags,
+        spin: AngularMomentum,
+        projection: Projection,
+        lambda_produced: Projection,
+        lambda_recoil: Projection,
+        frame: Frame,
+    ) -> LadduResult<Expression> {
+        let lambda = Projection::half_integer(lambda_produced.value() - lambda_recoil.value());
+        let angles = self.angles(frame)?;
+        Ok(WignerD::new(tags, spin, projection, lambda, &angles)?.conj())
+    }
+
+    fn canonical_factor(
+        &self,
+        tags: impl IntoTags,
+        spin: AngularMomentum,
+        projection: Projection,
+        orbital_l: OrbitalAngularMomentum,
+        coupled_spin: AngularMomentum,
+        produced_spin: AngularMomentum,
+        recoil_spin: AngularMomentum,
+        lambda_produced: Projection,
+        lambda_recoil: Projection,
+        frame: Frame,
+    ) -> LadduResult<Expression> {
+        let lambda = Projection::half_integer(lambda_produced.value() - lambda_recoil.value());
+        let minus_lambda_recoil = Projection::half_integer(-lambda_recoil.value());
+        Ok(
+            Expression::from(f64::from(2 * orbital_l.value() + 1).sqrt())
+                * ClebschGordan::new(
+                    (),
+                    orbital_l.angular_momentum(),
+                    Projection::integer(0),
+                    coupled_spin,
+                    lambda,
+                    spin,
+                    lambda,
+                )?
+                * ClebschGordan::new(
+                    (),
+                    produced_spin,
+                    lambda_produced,
+                    recoil_spin,
+                    minus_lambda_recoil,
+                    coupled_spin,
+                    lambda,
+                )?
+                * self.helicity_factor(
+                    tags,
+                    spin,
+                    projection,
+                    lambda_produced,
+                    lambda_recoil,
+                    frame,
+                )?,
         )
     }
 }

--- a/crates/laddu-amplitudes/src/lib.rs
+++ b/crates/laddu-amplitudes/src/lib.rs
@@ -22,7 +22,7 @@ pub use lookup::{LookupAxis, LookupBoundaryMode, LookupInterpolation, LookupTabl
 pub mod angular;
 pub use angular::{
     BlattWeisskopf, ClebschGordan, DecayAmplitudeExt, PhotonHelicity, PhotonPolarization,
-    PhotonSDME, PolPhase, Wigner3j, WignerD, Ylm, Zlm,
+    PhotonSDME, PolPhase, ProductionAmplitudeExt, Wigner3j, WignerD, Ylm, Zlm,
 };
 
 /// Resonance line shapes and related factors.

--- a/crates/laddu-core/src/data/io.rs
+++ b/crates/laddu-core/src/data/io.rs
@@ -772,6 +772,111 @@ pub fn write_parquet(
     dataset.write_parquet_impl(path, options)
 }
 
+/// Incrementally writes compatible [`Dataset`] batches to one Parquet file.
+pub struct ParquetBatchWriter {
+    file_path: PathBuf,
+    options: DatasetWriteOptions,
+    writer: Option<ArrowWriter<File>>,
+    metadata: Option<Arc<DatasetMetadata>>,
+    schema: Option<Arc<Schema>>,
+    closed: bool,
+}
+
+impl ParquetBatchWriter {
+    /// Construct a streaming Parquet writer.
+    pub fn new(file_path: &str, options: DatasetWriteOptions) -> LadduResult<Self> {
+        Ok(Self {
+            file_path: expand_output_path(file_path)?,
+            options,
+            writer: None,
+            metadata: None,
+            schema: None,
+            closed: false,
+        })
+    }
+
+    /// Append one dataset batch to this Parquet file.
+    pub fn write(&mut self, dataset: &Dataset) -> LadduResult<()> {
+        if self.closed {
+            return Err(LadduError::Custom(
+                "Cannot write to a closed ParquetBatchWriter".to_string(),
+            ));
+        }
+        self.ensure_open(dataset)?;
+        let schema = self
+            .schema
+            .as_ref()
+            .expect("streaming writer should have a schema after opening")
+            .clone();
+        let precision = self.options.precision;
+        let batch_size = self.options.batch_size.max(1);
+        let storage = dataset.local_storage_for_export()?;
+        let n_rows = storage.n_events();
+        let mut start = 0usize;
+        while start < n_rows {
+            let end = (start + batch_size).min(n_rows);
+            let batch =
+                columnar_range_to_record_batch(&storage, start, end, schema.clone(), precision)
+                    .map_err(|err| {
+                        LadduError::Custom(format!("Failed to build Parquet batch: {err}"))
+                    })?;
+            self.writer
+                .as_mut()
+                .expect("streaming writer should be open before writing")
+                .write(&batch)
+                .map_err(|err| {
+                    LadduError::Custom(format!("Failed to write Parquet batch: {err}"))
+                })?;
+            start = end;
+        }
+        Ok(())
+    }
+
+    /// Finalize the Parquet file.
+    pub fn close(&mut self) -> LadduResult<()> {
+        if self.closed {
+            return Ok(());
+        }
+        self.closed = true;
+        if let Some(writer) = self.writer.take() {
+            writer.close().map_err(|err| {
+                LadduError::Custom(format!("Failed to finalise Parquet file: {err}"))
+            })?;
+        }
+        Ok(())
+    }
+
+    fn ensure_open(&mut self, dataset: &Dataset) -> LadduResult<()> {
+        if let Some(metadata) = &self.metadata {
+            if metadata.p4_names() != dataset.p4_names()
+                || metadata.aux_names() != dataset.aux_names()
+            {
+                return Err(LadduError::Custom(
+                    "Dataset batch metadata does not match previous Parquet writer batches"
+                        .to_string(),
+                ));
+            }
+            return Ok(());
+        }
+
+        let metadata = Arc::new(dataset.metadata().clone());
+        let schema = Arc::new(build_parquet_schema(&metadata, self.options.precision));
+        let file = File::create(&self.file_path)?;
+        let writer = ArrowWriter::try_new(file, schema.clone(), None)
+            .map_err(|err| LadduError::Custom(format!("Failed to create Parquet writer: {err}")))?;
+        self.metadata = Some(metadata);
+        self.schema = Some(schema);
+        self.writer = Some(writer);
+        Ok(())
+    }
+}
+
+impl Drop for ParquetBatchWriter {
+    fn drop(&mut self) {
+        let _ = self.close();
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn write_parquet_storage(
     dataset: &DatasetStorage,

--- a/crates/laddu-core/src/data/tests.rs
+++ b/crates/laddu-core/src/data/tests.rs
@@ -1740,6 +1740,32 @@ fn test_parquet_roundtrip_incremental_small_batches() {
 }
 
 #[test]
+fn test_parquet_batch_writer_roundtrip_multiple_batches() {
+    let dataset = open_test_dataset("data_f32.parquet", DatasetReadOptions::new());
+    let dir = make_temp_dir();
+    let path = dir.join("streaming_batches.parquet");
+    let path_str = path.to_str().expect("path should be valid UTF-8");
+
+    let mut writer =
+        io::ParquetBatchWriter::new(path_str, DatasetWriteOptions::default().batch_size(1))
+            .expect("streaming writer should construct");
+    writer
+        .write(&dataset)
+        .expect("first dataset batch should write");
+    writer
+        .write(&dataset)
+        .expect("second dataset batch should write");
+    writer.close().expect("streaming writer should close");
+
+    let reopened = read_parquet(path_str, &DatasetReadOptions::new())
+        .expect("parquet roundtrip should reopen");
+    assert_eq!(reopened.n_events(), dataset.n_events() * 2);
+    assert_eq!(reopened.p4_names(), dataset.p4_names());
+    assert_eq!(reopened.aux_names(), dataset.aux_names());
+    fs::remove_dir_all(&dir).expect("temp dir cleanup should succeed");
+}
+
+#[test]
 fn test_parquet_read_order_is_deterministic_across_repeated_reads() {
     let dataset = open_test_dataset("data_f32.parquet", DatasetReadOptions::new());
     let dir = make_temp_dir();

--- a/crates/laddu-core/src/lib.rs
+++ b/crates/laddu-core/src/lib.rs
@@ -583,7 +583,7 @@ pub use crate::{
         RuleSet, SelectionRules, SpinState, Statistics,
     },
     reaction::{
-        Decay, Particle, ParticleGraph, ParticleSource, Reaction, ReactionTopology,
+        Decay, Particle, ParticleGraph, ParticleSource, Production, Reaction, ReactionTopology,
         ResolvedTwoToTwo, TwoToTwoReaction,
     },
     resources::{

--- a/crates/laddu-core/src/reaction.rs
+++ b/crates/laddu-core/src/reaction.rs
@@ -3,6 +3,7 @@
 mod decay;
 mod graph;
 mod particle;
+mod production;
 #[cfg(test)]
 mod tests;
 mod topology;
@@ -11,5 +12,6 @@ mod two_to_two;
 pub use decay::*;
 pub use graph::*;
 pub use particle::*;
+pub use production::*;
 pub use topology::*;
 pub use two_to_two::*;

--- a/crates/laddu-core/src/reaction/production.rs
+++ b/crates/laddu-core/src/reaction/production.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+use super::Reaction;
+use crate::{
+    quantum::Frame,
+    variables::{Angles, CosTheta, Phi},
+    LadduResult,
+};
+
+/// A two-to-two production view used to derive production-local variables and amplitudes.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Production {
+    pub(super) reaction: Reaction,
+    pub(super) produced: String,
+    pub(super) recoil: String,
+}
+
+impl Production {
+    /// Return the enclosing reaction.
+    pub const fn reaction(&self) -> &Reaction {
+        &self.reaction
+    }
+
+    /// Return the produced-system particle identifier.
+    pub fn produced(&self) -> &str {
+        &self.produced
+    }
+
+    /// Return the recoil particle identifier.
+    pub fn recoil(&self) -> &str {
+        &self.recoil
+    }
+
+    /// Return the production costheta variable.
+    pub fn costheta(&self, frame: Frame) -> LadduResult<CosTheta> {
+        Ok(CosTheta::from_production(
+            self.reaction.clone(),
+            self.produced.clone(),
+            frame,
+        ))
+    }
+
+    /// Return the production phi variable.
+    pub fn phi(&self, frame: Frame) -> LadduResult<Phi> {
+        Ok(Phi::from_production(
+            self.reaction.clone(),
+            self.produced.clone(),
+            frame,
+        ))
+    }
+
+    /// Return both production angle variables.
+    pub fn angles(&self, frame: Frame) -> LadduResult<Angles> {
+        Ok(Angles::from_production(
+            self.reaction.clone(),
+            self.produced.clone(),
+            frame,
+        ))
+    }
+}

--- a/crates/laddu-core/src/reaction/tests.rs
+++ b/crates/laddu-core/src/reaction/tests.rs
@@ -345,3 +345,33 @@ fn production_frame_axes_support_known_frames() {
     assert!(reaction.axes(&event, "x", Frame::GottfriedJackson).is_ok());
     assert!(reaction.axes(&event, "x", Frame::Adair).is_err());
 }
+
+#[test]
+fn reaction_production_view_infers_two_to_two_roles() {
+    let (_, reaction, _, _, _) = pion_cascade_dataset();
+    let production = reaction.production().unwrap();
+
+    assert_eq!(production.produced(), "x");
+    assert_eq!(production.recoil(), "recoil");
+    assert_eq!(production.reaction(), &reaction);
+}
+
+#[test]
+fn production_angles_use_two_to_two_scattering_geometry() {
+    let (dataset, reaction, _, _, _) = pion_cascade_dataset();
+    let event = dataset.event_local(0).unwrap();
+
+    let helicity = reaction
+        .production_angles_value(&event, "x", Frame::Helicity)
+        .unwrap();
+    let gj = reaction
+        .production_angles_value(&event, "x", Frame::GottfriedJackson)
+        .unwrap();
+
+    assert_relative_eq!(helicity.costheta(), 1.0);
+    assert!(gj.costheta() < 1.0);
+    assert!(gj.costheta() > -1.0);
+    assert!(reaction
+        .production_angles_value(&event, "rho", Frame::Helicity)
+        .is_err());
+}

--- a/crates/laddu-core/src/reaction/topology.rs
+++ b/crates/laddu-core/src/reaction/topology.rs
@@ -4,6 +4,7 @@ use super::{
     decay::Decay,
     graph::ParticleGraph,
     particle::{resolve_particle_direct, Particle},
+    production::Production,
     two_to_two::{ResolvedTwoToTwo, TwoToTwoReaction},
 };
 use crate::{
@@ -129,6 +130,16 @@ impl Reaction {
         })
     }
 
+    /// Construct a two-to-two production view.
+    pub fn production(&self) -> LadduResult<Production> {
+        let topology = self.two_to_two_topology()?;
+        Ok(Production {
+            reaction: self.clone(),
+            produced: topology.p3().to_string(),
+            recoil: topology.p4().to_string(),
+        })
+    }
+
     /// Construct a Mandelstam variable for this reaction.
     pub fn mandelstam(&self, channel: Channel) -> LadduResult<Mandelstam> {
         self.topology.require_mandelstam()?;
@@ -210,6 +221,37 @@ impl Reaction {
         }
         let axes = self.axes(event, parent, frame)?;
         axes.angles(self.p4_in_rest_frame_of(event, parent, daughter)?.vec3())
+    }
+
+    /// Compute the produced-system production angles in the overall center-of-momentum frame.
+    pub fn production_angles_value(
+        &self,
+        event: &dyn EventLike,
+        produced: &str,
+        frame: Frame,
+    ) -> LadduResult<DecayAngles> {
+        let topology = self.two_to_two_topology()?;
+        if produced != topology.p3() {
+            return Err(LadduError::Custom(format!(
+                "particle '{produced}' is not the produced p3 system"
+            )));
+        }
+        let resolved = self.resolve_two_to_two(event)?;
+        let com_boost = resolved.com_boost();
+        let reference = resolved.p1.boost(&com_boost);
+        let produced_p4 = resolved.p3.boost(&com_boost);
+        let produced_vec = produced_p4.vec3();
+        let plane_normal = reference.vec3().cross(&produced_vec);
+        let z = match frame {
+            Frame::Helicity => produced_vec,
+            Frame::GottfriedJackson => reference.vec3(),
+            Frame::Adair => {
+                return Err(LadduError::Custom(
+                    "Adair frame construction is not implemented yet".to_string(),
+                ));
+            }
+        };
+        FrameAxes::from_z_and_plane_normal(z, plane_normal)?.angles(produced_vec)
     }
 
     /// Return the particle with the given identifier.

--- a/crates/laddu-core/src/variables/angles.rs
+++ b/crates/laddu-core/src/variables/angles.rs
@@ -11,10 +11,16 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-struct AngleSource {
-    reaction: Box<Reaction>,
-    parent: String,
-    daughter: String,
+enum AngleSource {
+    Decay {
+        reaction: Box<Reaction>,
+        parent: String,
+        daughter: String,
+    },
+    Production {
+        reaction: Box<Reaction>,
+        produced: String,
+    },
 }
 
 impl AngleSource {
@@ -24,17 +30,59 @@ impl AngleSource {
     }
 
     fn costheta(&self, event: &dyn EventLike, frame: Frame) -> f64 {
-        self.reaction
-            .angles_value(event, &self.parent, &self.daughter, frame)
-            .unwrap_or_else(|err| panic!("failed to evaluate reaction costheta: {err}"))
-            .costheta()
+        match self {
+            Self::Decay {
+                reaction,
+                parent,
+                daughter,
+            } => reaction
+                .angles_value(event, parent, daughter, frame)
+                .unwrap_or_else(|err| panic!("failed to evaluate reaction costheta: {err}"))
+                .costheta(),
+            Self::Production { reaction, produced } => reaction
+                .production_angles_value(event, produced, frame)
+                .unwrap_or_else(|err| panic!("failed to evaluate production costheta: {err}"))
+                .costheta(),
+        }
     }
 
     fn phi(&self, event: &dyn EventLike, frame: Frame) -> f64 {
-        self.reaction
-            .angles_value(event, &self.parent, &self.daughter, frame)
-            .unwrap_or_else(|err| panic!("failed to evaluate reaction phi: {err}"))
-            .phi()
+        match self {
+            Self::Decay {
+                reaction,
+                parent,
+                daughter,
+            } => reaction
+                .angles_value(event, parent, daughter, frame)
+                .unwrap_or_else(|err| panic!("failed to evaluate reaction phi: {err}"))
+                .phi(),
+            Self::Production { reaction, produced } => reaction
+                .production_angles_value(event, produced, frame)
+                .unwrap_or_else(|err| panic!("failed to evaluate production phi: {err}"))
+                .phi(),
+        }
+    }
+
+    fn label(&self, kind: &str, frame: Frame) -> String {
+        match self {
+            Self::Decay {
+                parent, daughter, ..
+            } => format!("{kind}(parent={parent}, daughter={daughter}, frame={frame})"),
+            Self::Production { produced, .. } => {
+                format!("{kind}(produced={produced}, frame={frame})")
+            }
+        }
+    }
+
+    fn angles_label(&self, frame: Frame) -> String {
+        match self {
+            Self::Decay {
+                parent, daughter, ..
+            } => format!("Angles(parent={parent}, daughter={daughter}, frame={frame})"),
+            Self::Production { produced, .. } => {
+                format!("Angles(produced={produced}, frame={frame})")
+            }
+        }
     }
 }
 
@@ -47,11 +95,7 @@ pub struct CosTheta {
 
 impl Display for CosTheta {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "CosTheta(parent={}, daughter={}, frame={})",
-            self.source.parent, self.source.daughter, self.frame
-        )
+        write!(f, "{}", self.source.label("CosTheta", self.frame))
     }
 }
 
@@ -64,10 +108,21 @@ impl CosTheta {
         frame: Frame,
     ) -> Self {
         Self {
-            source: AngleSource {
+            source: AngleSource::Decay {
                 reaction: Box::new(reaction),
                 parent: parent.into(),
                 daughter: daughter.into(),
+            },
+            frame,
+        }
+    }
+
+    /// Construct an angle for the produced system in the production frame.
+    pub fn from_production(reaction: Reaction, produced: impl Into<String>, frame: Frame) -> Self {
+        Self {
+            source: AngleSource::Production {
+                reaction: Box::new(reaction),
+                produced: produced.into(),
             },
             frame,
         }
@@ -94,11 +149,7 @@ pub struct Phi {
 
 impl Display for Phi {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Phi(parent={}, daughter={}, frame={})",
-            self.source.parent, self.source.daughter, self.frame
-        )
+        write!(f, "{}", self.source.label("Phi", self.frame))
     }
 }
 
@@ -111,10 +162,21 @@ impl Phi {
         frame: Frame,
     ) -> Self {
         Self {
-            source: AngleSource {
+            source: AngleSource::Decay {
                 reaction: Box::new(reaction),
                 parent: parent.into(),
                 daughter: daughter.into(),
+            },
+            frame,
+        }
+    }
+
+    /// Construct an angle for the produced system in the production frame.
+    pub fn from_production(reaction: Reaction, produced: impl Into<String>, frame: Frame) -> Self {
+        Self {
+            source: AngleSource::Production {
+                reaction: Box::new(reaction),
+                produced: produced.into(),
             },
             frame,
         }
@@ -145,8 +207,8 @@ impl Display for Angles {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Angles(parent={}, daughter={}, frame={})",
-            self.costheta.source.parent, self.costheta.source.daughter, self.costheta.frame
+            "{}",
+            self.costheta.source.angles_label(self.costheta.frame)
         )
     }
 }
@@ -174,6 +236,14 @@ impl Angles {
         let costheta =
             CosTheta::from_reaction(reaction.clone(), parent.clone(), daughter.clone(), frame);
         let phi = Phi::from_reaction(reaction, parent, daughter, frame);
+        Self { costheta, phi }
+    }
+
+    /// Construct reaction-derived production angle variables.
+    pub fn from_production(reaction: Reaction, produced: impl Into<String>, frame: Frame) -> Self {
+        let produced = produced.into();
+        let costheta = CosTheta::from_production(reaction.clone(), produced.clone(), frame);
+        let phi = Phi::from_production(reaction, produced, frame);
         Self { costheta, phi }
     }
 }

--- a/crates/laddu-generation/src/lib.rs
+++ b/crates/laddu-generation/src/lib.rs
@@ -5,9 +5,10 @@ pub use distributions::{
     Distribution, HistogramSampler, LadduGenRngExt, MandelstamTDistribution, SimpleDistribution,
 };
 pub use topology::{
-    BatchIntensity, CompositeGenerator, EventGenerator, GeneratedBatch, GeneratedEventLayout,
-    GeneratedParticle, GeneratedParticleLayout, GeneratedReaction, GeneratedReactionTopology,
-    GeneratedStorage, GeneratedTwoToTwoReaction, GeneratedVertexKind, GeneratedVertexLayout,
-    InitialGenerator, ParticleSpecies, Reconstruction, RejectionEnvelope, RejectionSampleIter,
-    RejectionSampler, RejectionSamplingDiagnostics, RejectionSamplingOptions, StableGenerator,
+    BatchIntensity, CompositeGenerator, EventGenerator, ExpressionIntensity, GeneratedBatch,
+    GeneratedEventLayout, GeneratedParticle, GeneratedParticleLayout, GeneratedReaction,
+    GeneratedReactionTopology, GeneratedStorage, GeneratedTwoToTwoReaction, GeneratedVertexKind,
+    GeneratedVertexLayout, InitialGenerator, ParticleSpecies, Reconstruction, RejectionEnvelope,
+    RejectionSampleIter, RejectionSampler, RejectionSamplingDiagnostics, RejectionSamplingOptions,
+    StableGenerator,
 };

--- a/crates/laddu-generation/src/topology.rs
+++ b/crates/laddu-generation/src/topology.rs
@@ -1,9 +1,13 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use fastrand::Rng;
 use laddu_core::{
     math::{q_m, Histogram, Sheet},
-    Dataset, DatasetMetadata, LadduError, LadduResult, Particle, Reaction, Vec3, Vec4, PI,
+    Dataset, DatasetMetadata, Expression, LadduError, LadduResult, Particle, Reaction, Vec3, Vec4,
+    PI,
 };
 use serde::{Deserialize, Serialize};
 
@@ -1107,16 +1111,73 @@ impl Iterator for GeneratedBatchIter {
 
 /// Evaluates unnormalized intensities for generated batches.
 pub trait BatchIntensity {
-    /// Return one nonnegative finite intensity for each event in `batch`.
-    fn evaluate(&mut self, batch: &GeneratedBatch) -> LadduResult<Vec<f64>>;
+    /// Return one real-valued intensity for each event in `batch`.
+    fn evaluate(&self, batch: &GeneratedBatch) -> LadduResult<Vec<f64>>;
+
+    /// Evaluate and validate one finite nonnegative intensity for each event in `batch`.
+    fn evaluate_checked(&self, batch: &GeneratedBatch) -> LadduResult<Vec<f64>> {
+        let intensities = self.evaluate(batch)?;
+        if intensities.len() != batch.dataset().n_events() {
+            return Err(LadduError::Custom(format!(
+                "intensity length mismatch: expected {}, got {}",
+                batch.dataset().n_events(),
+                intensities.len()
+            )));
+        }
+        for (index, weight) in intensities.iter().enumerate() {
+            if !weight.is_finite() || *weight < 0.0 {
+                return Err(LadduError::Custom(format!(
+                    "intensity at event {index} must be finite and nonnegative, got {weight}"
+                )));
+            }
+        }
+        Ok(intensities)
+    }
 }
 
 impl<F> BatchIntensity for F
 where
-    F: FnMut(&GeneratedBatch) -> LadduResult<Vec<f64>>,
+    F: Fn(&GeneratedBatch) -> LadduResult<Vec<f64>>,
 {
-    fn evaluate(&mut self, batch: &GeneratedBatch) -> LadduResult<Vec<f64>> {
+    fn evaluate(&self, batch: &GeneratedBatch) -> LadduResult<Vec<f64>> {
         self(batch)
+    }
+}
+
+/// Evaluates a real-valued [`Expression`] as a generated-batch intensity.
+#[derive(Clone, Debug)]
+pub struct ExpressionIntensity {
+    expression: Expression,
+    parameters: Vec<f64>,
+}
+
+impl ExpressionIntensity {
+    /// Construct an expression-backed generated-batch intensity.
+    pub fn new(expression: Expression, parameters: Vec<f64>) -> Self {
+        Self {
+            expression,
+            parameters,
+        }
+    }
+}
+
+impl BatchIntensity for ExpressionIntensity {
+    fn evaluate(&self, batch: &GeneratedBatch) -> LadduResult<Vec<f64>> {
+        let dataset = Arc::new(batch.dataset().clone());
+        let evaluator = self.expression.load(&dataset)?;
+        evaluator
+            .evaluate(&self.parameters)?
+            .into_iter()
+            .enumerate()
+            .map(|(index, value)| {
+                if !value.im.is_finite() || value.im.abs() > f64::EPSILON {
+                    return Err(LadduError::Custom(format!(
+                        "expression intensity at event {index} must be real-valued, got {value}"
+                    )));
+                }
+                Ok(value.re)
+            })
+            .collect()
     }
 }
 
@@ -1128,14 +1189,15 @@ pub enum RejectionEnvelope {
         /// Maximum event weight used as the rejection envelope.
         max_weight: f64,
     },
-}
-
-impl RejectionEnvelope {
-    fn max_weight(&self) -> f64 {
-        match self {
-            Self::Fixed { max_weight } => *max_weight,
-        }
-    }
+    /// Estimate the maximum event weight from a pilot sample and inflate it.
+    Pilot {
+        /// Number of pilot events used to estimate the envelope.
+        pilot_events: usize,
+        /// Optional raw generation batch size used for pilot evaluation.
+        batch_size: Option<usize>,
+        /// Multiplicative safety factor applied to the observed maximum.
+        safety_factor: f64,
+    },
 }
 
 /// Options for rejection sampling generated events.
@@ -1186,6 +1248,7 @@ impl RejectionSamplingDiagnostics {
 pub struct RejectionSampler<I> {
     generator: EventGenerator,
     intensity: I,
+    max_weight: f64,
     options: RejectionSamplingOptions,
 }
 
@@ -1209,7 +1272,20 @@ where
                 "output_batch_size must be greater than zero".to_string(),
             ));
         }
-        let max_weight = options.envelope.max_weight();
+        let max_weight = match options.envelope {
+            RejectionEnvelope::Fixed { max_weight } => max_weight,
+            RejectionEnvelope::Pilot {
+                pilot_events,
+                batch_size,
+                safety_factor,
+            } => estimate_rejection_envelope(
+                &generator,
+                &intensity,
+                pilot_events,
+                batch_size.unwrap_or(options.generation_batch_size),
+                safety_factor,
+            )?,
+        };
         if !max_weight.is_finite() || max_weight <= 0.0 {
             return Err(LadduError::Custom(
                 "rejection envelope max_weight must be finite and positive".to_string(),
@@ -1218,18 +1294,18 @@ where
         Ok(Self {
             generator,
             intensity,
+            max_weight,
             options,
         })
     }
 
     /// Consume this sampler and return an iterator over accepted generated batches.
     pub fn accepted_batches(self) -> RejectionSampleIter<I> {
-        let envelope_max_weight = self.options.envelope.max_weight();
         RejectionSampleIter {
             generation_rng: Rng::with_seed(self.generator.seed),
             rejection_rng: Rng::with_seed(self.options.seed),
             diagnostics: RejectionSamplingDiagnostics {
-                envelope_max_weight,
+                envelope_max_weight: self.max_weight,
                 ..Default::default()
             },
             sampler: self,
@@ -1238,6 +1314,54 @@ where
             current_index: 0,
         }
     }
+}
+
+fn estimate_rejection_envelope<I>(
+    generator: &EventGenerator,
+    intensity: &I,
+    pilot_events: usize,
+    batch_size: usize,
+    safety_factor: f64,
+) -> LadduResult<f64>
+where
+    I: BatchIntensity,
+{
+    if pilot_events == 0 {
+        return Err(LadduError::Custom(
+            "pilot_events must be greater than zero".to_string(),
+        ));
+    }
+    if batch_size == 0 {
+        return Err(LadduError::Custom(
+            "pilot batch_size must be greater than zero".to_string(),
+        ));
+    }
+    if !safety_factor.is_finite() || safety_factor <= 0.0 {
+        return Err(LadduError::Custom(
+            "pilot safety_factor must be finite and positive".to_string(),
+        ));
+    }
+
+    let mut max_observed = 0.0_f64;
+    let mut rng = Rng::with_seed(generator.seed);
+    let mut remaining = pilot_events;
+    while remaining > 0 {
+        let n_events = remaining.min(batch_size);
+        let batch = generator.generate_batch_with_rng(n_events, &mut rng)?;
+        let weights = intensity.evaluate_checked(&batch)?;
+        for weight in weights {
+            max_observed = max_observed.max(weight);
+        }
+        remaining -= n_events;
+    }
+
+    let max_weight = max_observed * safety_factor;
+    if !max_weight.is_finite() || max_weight <= 0.0 {
+        return Err(LadduError::Custom(format!(
+            "pilot envelope produced invalid max_weight {max_weight}; observed maximum was {max_observed}"
+        )));
+    }
+    Ok(max_weight)
 }
 
 /// Iterator over accepted generated batches.
@@ -1268,14 +1392,7 @@ where
             self.sampler.options.generation_batch_size,
             &mut self.generation_rng,
         )?;
-        let intensities = self.sampler.intensity.evaluate(&batch)?;
-        if intensities.len() != batch.dataset().n_events() {
-            return Err(LadduError::Custom(format!(
-                "intensity length mismatch: expected {}, got {}",
-                batch.dataset().n_events(),
-                intensities.len()
-            )));
-        }
+        let intensities = self.sampler.intensity.evaluate_checked(&batch)?;
         self.diagnostics.generated_events += batch.dataset().n_events();
         self.current_batch = Some(batch);
         self.current_intensities = intensities;
@@ -1325,14 +1442,8 @@ where
             }
 
             let weight = self.current_intensities[self.current_index];
-            if !weight.is_finite() || weight < 0.0 {
-                return Some(Err(LadduError::Custom(format!(
-                    "intensity at event {} must be finite and nonnegative, got {weight}",
-                    self.current_index
-                ))));
-            }
             self.diagnostics.max_observed_weight = self.diagnostics.max_observed_weight.max(weight);
-            let envelope_max = self.sampler.options.envelope.max_weight();
+            let envelope_max = self.sampler.max_weight;
             if weight > envelope_max {
                 self.diagnostics.envelope_violations += 1;
                 return Some(Err(LadduError::Custom(format!(
@@ -1484,12 +1595,26 @@ impl EventGenerator {
     pub fn generate_dataset(&self, n_events: usize) -> LadduResult<Dataset> {
         Ok(self.generate_batch(n_events)?.into_dataset())
     }
+
+    /// Construct a rejection sampler using a real-valued expression intensity.
+    pub fn rejection_sampler_with_expression(
+        &self,
+        expression: Expression,
+        parameters: Vec<f64>,
+        options: RejectionSamplingOptions,
+    ) -> LadduResult<RejectionSampler<ExpressionIntensity>> {
+        RejectionSampler::new(
+            self.clone(),
+            ExpressionIntensity::new(expression, parameters),
+            options,
+        )
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use approx::assert_relative_eq;
-    use laddu_core::{traits::Variable, Channel, Frame};
+    use laddu_core::{traits::Variable, Channel, Expression, Frame};
 
     use super::*;
 
@@ -1922,6 +2047,120 @@ mod tests {
         assert!(err.is_err());
         assert_eq!(iter.diagnostics().envelope_violations, 1);
         assert_relative_eq!(iter.diagnostics().max_observed_weight, 2.0);
+    }
+
+    #[test]
+    fn rejection_sampler_validates_custom_batch_intensities() {
+        let generator = EventGenerator::new(demo_reaction(), HashMap::new(), Some(12345));
+        let sampler = RejectionSampler::new(
+            generator,
+            |batch: &GeneratedBatch| Ok(vec![f64::NAN; batch.dataset().n_events()]),
+            RejectionSamplingOptions {
+                target_accepted: 1,
+                generation_batch_size: 1,
+                output_batch_size: 1,
+                envelope: RejectionEnvelope::Fixed { max_weight: 1.0 },
+                seed: 67890,
+            },
+        )
+        .unwrap();
+
+        let err = sampler
+            .accepted_batches()
+            .next()
+            .expect("sampler should produce an error");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn expression_rejection_sampler_streams_exact_target_count() {
+        let generator = EventGenerator::new(demo_reaction(), HashMap::new(), Some(12345));
+        let sampler = generator
+            .rejection_sampler_with_expression(
+                Expression::from(1.0),
+                vec![],
+                RejectionSamplingOptions {
+                    target_accepted: 5,
+                    generation_batch_size: 4,
+                    output_batch_size: 2,
+                    envelope: RejectionEnvelope::Fixed { max_weight: 1.0 },
+                    seed: 67890,
+                },
+            )
+            .unwrap();
+
+        let batches = sampler
+            .accepted_batches()
+            .collect::<LadduResult<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            batches
+                .iter()
+                .map(|batch| batch.dataset().n_events())
+                .collect::<Vec<_>>(),
+            vec![2, 2, 1]
+        );
+        assert_eq!(
+            batches
+                .iter()
+                .map(|batch| batch.dataset().n_events())
+                .sum::<usize>(),
+            5
+        );
+    }
+
+    #[test]
+    fn expression_rejection_sampler_supports_pilot_envelope() {
+        let generator = EventGenerator::new(demo_reaction(), HashMap::new(), Some(12345));
+        let sampler = generator
+            .rejection_sampler_with_expression(
+                Expression::from(1.0),
+                vec![],
+                RejectionSamplingOptions {
+                    target_accepted: 3,
+                    generation_batch_size: 2,
+                    output_batch_size: 2,
+                    envelope: RejectionEnvelope::Pilot {
+                        pilot_events: 4,
+                        batch_size: Some(2),
+                        safety_factor: 1.25,
+                    },
+                    seed: 67890,
+                },
+            )
+            .unwrap();
+        let mut iter = sampler.accepted_batches();
+        let batches = iter.by_ref().collect::<LadduResult<Vec<_>>>().unwrap();
+        assert_eq!(
+            batches
+                .iter()
+                .map(|batch| batch.dataset().n_events())
+                .sum::<usize>(),
+            3
+        );
+        assert_relative_eq!(iter.diagnostics().envelope_max_weight, 1.25);
+    }
+
+    #[test]
+    fn expression_rejection_sampler_rejects_invalid_intensities() {
+        let generator = EventGenerator::new(demo_reaction(), HashMap::new(), Some(12345));
+        let err = generator
+            .rejection_sampler_with_expression(
+                Expression::from(-1.0),
+                vec![],
+                RejectionSamplingOptions {
+                    target_accepted: 1,
+                    generation_batch_size: 1,
+                    output_batch_size: 1,
+                    envelope: RejectionEnvelope::Fixed { max_weight: 1.0 },
+                    seed: 67890,
+                },
+            )
+            .unwrap()
+            .accepted_batches()
+            .next()
+            .expect("sampler should emit an error");
+        assert!(err.is_err());
     }
 
     #[test]

--- a/crates/laddu-python/Cargo.toml
+++ b/crates/laddu-python/Cargo.toml
@@ -19,6 +19,7 @@ laddu-extensions = { workspace = true }
 laddu-generation = { workspace = true }
 
 ganesh = { workspace = true, features = ["python"] }
+fastrand = { workspace = true }
 num = { workspace = true }
 num_cpus = { workspace = true }
 numpy = { workspace = true }

--- a/crates/laddu-python/src/data.rs
+++ b/crates/laddu-python/src/data.rs
@@ -4,7 +4,8 @@ use laddu_core::{
     data::{
         io::{
             infer_p4_and_aux_names_from_columns, resolve_columns_case_insensitive,
-            resolve_optional_weight_column, resolve_p4_component_columns, P4_COMPONENT_SUFFIXES,
+            resolve_optional_weight_column, resolve_p4_component_columns, ParquetBatchWriter,
+            P4_COMPONENT_SUFFIXES,
         },
         read_parquet as core_read_parquet,
         read_parquet_chunks_with_options as core_read_parquet_chunks_with_options,
@@ -527,6 +528,59 @@ impl PyParquetChunkIter {
             Some(Err(err)) => Err(PyErr::from(err)),
             None => Ok(None),
         }
+    }
+}
+
+/// Streaming writer for appending compatible Dataset batches to one Parquet file.
+#[pyclass(name = "ParquetBatchWriter", module = "laddu", unsendable)]
+pub struct PyParquetBatchWriter {
+    writer: Option<ParquetBatchWriter>,
+}
+
+#[pymethods]
+impl PyParquetBatchWriter {
+    /// Append one Dataset batch.
+    fn write(&mut self, dataset: &PyDataset) -> PyResult<()> {
+        self.writer_mut()?
+            .write(dataset.0.as_ref())
+            .map_err(PyErr::from)
+    }
+
+    /// Finalize the Parquet file.
+    fn close(&mut self) -> PyResult<()> {
+        if let Some(writer) = &mut self.writer {
+            writer.close()?;
+        }
+        self.writer = None;
+        Ok(())
+    }
+
+    fn __enter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    fn __exit__(
+        &mut self,
+        _exc_type: Bound<'_, PyAny>,
+        _exc_value: Bound<'_, PyAny>,
+        _traceback: Bound<'_, PyAny>,
+    ) -> PyResult<bool> {
+        self.close()?;
+        Ok(false)
+    }
+}
+
+impl PyParquetBatchWriter {
+    fn new(writer: ParquetBatchWriter) -> Self {
+        Self {
+            writer: Some(writer),
+        }
+    }
+
+    fn writer_mut(&mut self) -> PyResult<&mut ParquetBatchWriter> {
+        self.writer
+            .as_mut()
+            .ok_or_else(|| PyValueError::new_err("ParquetBatchWriter is closed"))
     }
 }
 
@@ -1232,6 +1286,26 @@ pub fn write_parquet(
     }
     write_options.precision = parse_precision_arg(Some(precision))?;
     core_write_parquet(dataset.0.as_ref(), &path_str, &write_options).map_err(PyErr::from)
+}
+
+/// Open a streaming Parquet writer for compatible Dataset batches.
+#[pyfunction]
+#[pyo3(signature = (path, *, chunk_size=None, precision="f64"))]
+pub fn open_parquet_writer(
+    path: Bound<PyAny>,
+    chunk_size: Option<usize>,
+    precision: &str,
+) -> PyResult<PyParquetBatchWriter> {
+    let path_str = parse_dataset_path(path)?;
+    let mut write_options = DatasetWriteOptions::default();
+    if let Some(size) = chunk_size {
+        write_options.batch_size = size.max(1);
+    }
+    write_options.precision = parse_precision_arg(Some(precision))?;
+    Ok(PyParquetBatchWriter::new(ParquetBatchWriter::new(
+        &path_str,
+        write_options,
+    )?))
 }
 
 /// Write a Dataset to a ROOT file using the oxyroot backend.

--- a/crates/laddu-python/src/generation.rs
+++ b/crates/laddu-python/src/generation.rs
@@ -1,14 +1,18 @@
 use std::{collections::HashMap, sync::Arc};
 
 use laddu_generation::{
-    CompositeGenerator, Distribution, EventGenerator, GeneratedBatch, GeneratedEventLayout,
-    GeneratedParticle, GeneratedParticleLayout, GeneratedReaction, GeneratedStorage,
-    GeneratedVertexKind, GeneratedVertexLayout, HistogramSampler, InitialGenerator,
-    MandelstamTDistribution, ParticleSpecies, Reconstruction, StableGenerator,
+    CompositeGenerator, Distribution, EventGenerator, ExpressionIntensity, GeneratedBatch,
+    GeneratedEventLayout, GeneratedParticle, GeneratedParticleLayout, GeneratedReaction,
+    GeneratedStorage, GeneratedVertexKind, GeneratedVertexLayout, HistogramSampler,
+    InitialGenerator, MandelstamTDistribution, ParticleSpecies, Reconstruction, RejectionEnvelope,
+    RejectionSampleIter, RejectionSamplingDiagnostics, RejectionSamplingOptions, StableGenerator,
 };
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyTuple};
 
-use crate::{data::PyDataset, math::PyHistogram, variables::PyReaction, vectors::PyVec4};
+use crate::{
+    amplitudes::PyExpression, data::PyDataset, math::PyHistogram, variables::PyReaction,
+    vectors::PyVec4,
+};
 
 /// A scalar distribution used by generated auxiliary columns.
 #[pyclass(name = "Distribution", module = "laddu", from_py_object)]
@@ -671,6 +675,116 @@ impl PyGeneratedBatchIter {
     }
 }
 
+/// Envelope strategy used by rejection sampling.
+#[pyclass(name = "RejectionEnvelope", module = "laddu", from_py_object)]
+#[derive(Clone, Debug)]
+pub struct PyRejectionEnvelope(pub RejectionEnvelope);
+
+#[pymethods]
+impl PyRejectionEnvelope {
+    /// Use a fixed maximum event weight.
+    #[staticmethod]
+    fn fixed(max_weight: f64) -> Self {
+        Self(RejectionEnvelope::Fixed { max_weight })
+    }
+
+    /// Estimate the maximum event weight from a pilot sample.
+    #[staticmethod]
+    #[pyo3(signature = (pilot_events, *, safety_factor=1.2, batch_size=None))]
+    fn pilot(pilot_events: usize, safety_factor: f64, batch_size: Option<usize>) -> Self {
+        Self(RejectionEnvelope::Pilot {
+            pilot_events,
+            batch_size,
+            safety_factor,
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{:?}", self.0)
+    }
+}
+
+/// Rejection-sampling diagnostics.
+#[pyclass(
+    name = "RejectionSamplingDiagnostics",
+    module = "laddu",
+    from_py_object
+)]
+#[derive(Clone, Debug)]
+pub struct PyRejectionSamplingDiagnostics(pub RejectionSamplingDiagnostics);
+
+#[pymethods]
+impl PyRejectionSamplingDiagnostics {
+    #[getter]
+    fn generated_events(&self) -> usize {
+        self.0.generated_events
+    }
+
+    #[getter]
+    fn accepted_events(&self) -> usize {
+        self.0.accepted_events
+    }
+
+    #[getter]
+    fn rejected_events(&self) -> usize {
+        self.0.rejected_events
+    }
+
+    #[getter]
+    fn max_observed_weight(&self) -> f64 {
+        self.0.max_observed_weight
+    }
+
+    #[getter]
+    fn envelope_max_weight(&self) -> f64 {
+        self.0.envelope_max_weight
+    }
+
+    #[getter]
+    fn envelope_violations(&self) -> usize {
+        self.0.envelope_violations
+    }
+
+    fn acceptance_efficiency(&self) -> f64 {
+        self.0.acceptance_efficiency()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{:?}", self.0)
+    }
+}
+
+/// Iterator over expression rejection-sampled generated batches.
+#[pyclass(
+    name = "RejectionSampleIter",
+    module = "laddu",
+    unsendable,
+    skip_from_py_object
+)]
+pub struct PyRejectionSampleIter {
+    iter: RejectionSampleIter<ExpressionIntensity>,
+}
+
+#[pymethods]
+impl PyRejectionSampleIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> Py<PyRejectionSampleIter> {
+        slf.into()
+    }
+
+    fn __next__(&mut self) -> PyResult<Option<PyGeneratedBatch>> {
+        match self.iter.next() {
+            Some(Ok(batch)) => Ok(Some(PyGeneratedBatch(batch))),
+            Some(Err(err)) => Err(PyErr::from(err)),
+            None => Ok(None),
+        }
+    }
+
+    #[getter]
+    fn diagnostics(&self) -> PyRejectionSamplingDiagnostics {
+        PyRejectionSamplingDiagnostics(self.iter.diagnostics().clone())
+    }
+}
+
 /// Event generator for generated reaction layouts.
 #[pyclass(name = "EventGenerator", module = "laddu", from_py_object)]
 #[derive(Clone, Debug)]
@@ -718,6 +832,98 @@ impl PyEventGenerator {
         Ok(PyGeneratedBatchIter {
             iter: Box::new(self.0.generate_batches(total_events, batch_size)?),
         })
+    }
+
+    /// Generate accepted batches using a real-valued expression as the rejection intensity.
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        expression,
+        parameters,
+        *,
+        n_events,
+        generation_batch_size,
+        output_batch_size,
+        envelope,
+        seed=None
+    ))]
+    fn generate_batches_rejection(
+        &self,
+        expression: &PyExpression,
+        parameters: Vec<f64>,
+        n_events: usize,
+        generation_batch_size: usize,
+        output_batch_size: usize,
+        envelope: &PyRejectionEnvelope,
+        seed: Option<u64>,
+    ) -> PyResult<PyRejectionSampleIter> {
+        let sampler = self.0.rejection_sampler_with_expression(
+            expression.0.clone(),
+            parameters,
+            RejectionSamplingOptions {
+                target_accepted: n_events,
+                generation_batch_size,
+                output_batch_size,
+                envelope: envelope.0.clone(),
+                seed: seed.unwrap_or_else(|| fastrand::u64(..)),
+            },
+        )?;
+        Ok(PyRejectionSampleIter {
+            iter: sampler.accepted_batches(),
+        })
+    }
+
+    /// Generate a Dataset using a real-valued expression as the rejection intensity.
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        expression,
+        parameters,
+        *,
+        n_events,
+        generation_batch_size,
+        output_batch_size,
+        envelope,
+        seed=None
+    ))]
+    fn generate_dataset_rejection(
+        &self,
+        expression: &PyExpression,
+        parameters: Vec<f64>,
+        n_events: usize,
+        generation_batch_size: usize,
+        output_batch_size: usize,
+        envelope: &PyRejectionEnvelope,
+        seed: Option<u64>,
+    ) -> PyResult<PyDataset> {
+        let mut iter = self.generate_batches_rejection(
+            expression,
+            parameters,
+            n_events,
+            generation_batch_size,
+            output_batch_size,
+            envelope,
+            seed,
+        )?;
+        let mut output = None;
+        while let Some(batch) = iter.__next__()? {
+            let dataset = batch.0.into_dataset();
+            if output.is_none() {
+                output = Some(laddu_core::Dataset::empty_local(dataset.metadata().clone()));
+            }
+            let output_dataset = output.as_mut().expect("output dataset should exist");
+            for index in 0..dataset.n_events() {
+                let event = dataset.event_global(index)?;
+                output_dataset.push_event_local(
+                    event.p4s.clone(),
+                    event.aux.clone(),
+                    event.weight,
+                )?;
+            }
+        }
+        let output = match output {
+            Some(output) => output,
+            None => self.0.generate_batch(0)?.into_dataset(),
+        };
+        Ok(PyDataset(Arc::new(output)))
     }
 
     /// Generate a dataset.

--- a/crates/laddu-python/src/variables.rs
+++ b/crates/laddu-python/src/variables.rs
@@ -1,9 +1,9 @@
 use std::fmt::{Debug, Display};
 
-use laddu_amplitudes::DecayAmplitudeExt;
+use laddu_amplitudes::{DecayAmplitudeExt, ProductionAmplitudeExt};
 use laddu_core::{
     data::{Dataset, DatasetMetadata, EventLike, OwnedEvent},
-    reaction::{Decay, Particle, Reaction},
+    reaction::{Decay, Particle, Production, Reaction},
     traits::Variable,
     variables::{
         Angles, CosTheta, IntoP4Selection, Mandelstam, Mass, P4Selection, Phi, PolAngle,
@@ -210,6 +210,11 @@ impl PyReaction {
         Ok(PyDecay(self.0.decay(parent)?))
     }
 
+    /// Construct a two-to-two production view.
+    fn production(&self) -> PyResult<PyProduction> {
+        Ok(PyProduction(self.0.production()?))
+    }
+
     /// Construct a Mandelstam variable.
     fn mandelstam(&self, channel: &str) -> PyResult<PyMandelstam> {
         Ok(PyMandelstam(self.0.mandelstam(channel.parse()?)?))
@@ -221,6 +226,7 @@ impl PyReaction {
     }
 
     /// Construct polarization variables.
+    #[pyo3(signature=(*, pol_magnitude, pol_angle))]
     fn polarization(&self, pol_magnitude: String, pol_angle: String) -> PyResult<PyPolarization> {
         if pol_magnitude == pol_angle {
             return Err(PyValueError::new_err(
@@ -372,6 +378,110 @@ impl PyDecay {
             parse_angular_momentum(daughter_2_spin)?,
             parse_projection(lambda_1)?,
             parse_projection(lambda_2)?,
+            frame.parse()?,
+        )?))
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{:?}", self.0)
+    }
+
+    fn __str__(&self) -> String {
+        format!("{:?}", self.0)
+    }
+}
+
+/// A reaction-aware two-to-two production view.
+#[pyclass(name = "Production", module = "laddu", from_py_object)]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PyProduction(pub Production);
+
+#[pymethods]
+impl PyProduction {
+    /// The enclosing reaction.
+    #[getter]
+    fn reaction(&self) -> PyReaction {
+        PyReaction(self.0.reaction().clone())
+    }
+
+    /// The produced-system particle.
+    #[getter]
+    fn produced(&self) -> String {
+        self.0.produced().to_string()
+    }
+
+    /// The recoil particle.
+    #[getter]
+    fn recoil(&self) -> String {
+        self.0.recoil().to_string()
+    }
+
+    /// Production costheta variable for the selected frame.
+    #[pyo3(signature=(frame="Helicity"))]
+    fn costheta(&self, frame: &str) -> PyResult<PyCosTheta> {
+        Ok(PyCosTheta(self.0.costheta(frame.parse()?)?))
+    }
+
+    /// Production phi variable for the selected frame.
+    #[pyo3(signature=(frame="Helicity"))]
+    fn phi(&self, frame: &str) -> PyResult<PyPhi> {
+        Ok(PyPhi(self.0.phi(frame.parse()?)?))
+    }
+
+    /// Production angle variables for the selected frame.
+    #[pyo3(signature=(frame="Helicity"))]
+    fn angles(&self, frame: &str) -> PyResult<PyAngles> {
+        Ok(PyAngles(self.0.angles(frame.parse()?)?))
+    }
+
+    /// Construct the helicity-basis production angular factor for one explicit helicity term.
+    #[pyo3(signature=(*tags, spin, projection, lambda_produced, lambda_recoil, frame="Helicity"))]
+    #[allow(clippy::too_many_arguments)]
+    fn helicity_factor(
+        &self,
+        tags: &Bound<'_, PyTuple>,
+        spin: &Bound<'_, PyAny>,
+        projection: &Bound<'_, PyAny>,
+        lambda_produced: &Bound<'_, PyAny>,
+        lambda_recoil: &Bound<'_, PyAny>,
+        frame: &str,
+    ) -> PyResult<PyExpression> {
+        Ok(PyExpression(self.0.helicity_factor(
+            py_tags(tags)?,
+            parse_angular_momentum(spin)?,
+            parse_projection(projection)?,
+            parse_projection(lambda_produced)?,
+            parse_projection(lambda_recoil)?,
+            frame.parse()?,
+        )?))
+    }
+
+    /// Construct the canonical-basis production spin-angular factor for one LS/helicity term.
+    #[pyo3(signature=(*tags, spin, projection, orbital_l, coupled_spin, produced_spin, recoil_spin, lambda_produced, lambda_recoil, frame="Helicity"))]
+    #[allow(clippy::too_many_arguments)]
+    fn canonical_factor(
+        &self,
+        tags: &Bound<'_, PyTuple>,
+        spin: &Bound<'_, PyAny>,
+        projection: &Bound<'_, PyAny>,
+        orbital_l: &Bound<'_, PyAny>,
+        coupled_spin: &Bound<'_, PyAny>,
+        produced_spin: &Bound<'_, PyAny>,
+        recoil_spin: &Bound<'_, PyAny>,
+        lambda_produced: &Bound<'_, PyAny>,
+        lambda_recoil: &Bound<'_, PyAny>,
+        frame: &str,
+    ) -> PyResult<PyExpression> {
+        Ok(PyExpression(self.0.canonical_factor(
+            py_tags(tags)?,
+            parse_angular_momentum(spin)?,
+            parse_projection(projection)?,
+            parse_orbital_angular_momentum(orbital_l)?,
+            parse_angular_momentum(coupled_spin)?,
+            parse_angular_momentum(produced_spin)?,
+            parse_angular_momentum(recoil_spin)?,
+            parse_projection(lambda_produced)?,
+            parse_projection(lambda_recoil)?,
             frame.parse()?,
         )?))
     }

--- a/py-laddu-cpu/pyproject.toml
+++ b/py-laddu-cpu/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dynamic = ["version", "license", "description", "readme"]
 dependencies = [
   "numpy",
-  "ganesh-rs == 0.27.0",
+  "ganesh-rs == 0.27.1",
 ]
 
 [project.urls]

--- a/py-laddu-cpu/src/lib.rs
+++ b/py-laddu-cpu/src/lib.rs
@@ -56,7 +56,7 @@ mod laddu {
         set_threads,
         variables::{
             PyAngles, PyCosTheta, PyDecay, PyMandelstam, PyMass, PyParticle, PyPhi, PyPolAngle,
-            PyPolMagnitude, PyPolarization, PyReaction, PyVariableExpression,
+            PyPolMagnitude, PyPolarization, PyProduction, PyReaction, PyVariableExpression,
         },
         vectors::{PyVec3, PyVec4},
     };

--- a/py-laddu-cpu/src/lib.rs
+++ b/py-laddu-cpu/src/lib.rs
@@ -11,7 +11,8 @@ mod laddu {
 
     #[pymodule_export]
     use laddu_python::data::{
-        from_columns, read_parquet, read_parquet_chunked, read_root, write_parquet, write_root,
+        from_columns, open_parquet_writer, read_parquet, read_parquet_chunked, read_root,
+        write_parquet, write_root,
     };
     #[pymodule_export]
     use laddu_python::extensions::{
@@ -37,13 +38,14 @@ mod laddu {
             PyKopfKMatrixPi1Channel, PyKopfKMatrixRhoChannel, PyParameter, PyParameterMap,
         },
         available_parallelism,
-        data::{PyBinnedDataset, PyDataset, PyEvent, PyParquetChunkIter},
+        data::{PyBinnedDataset, PyDataset, PyEvent, PyParquetBatchWriter, PyParquetChunkIter},
         generation::{
             PyCompositeGenerator, PyDistribution, PyEventGenerator, PyGeneratedBatch,
             PyGeneratedBatchIter, PyGeneratedEventLayout, PyGeneratedParticle,
             PyGeneratedParticleLayout, PyGeneratedReaction, PyGeneratedStorage,
             PyGeneratedVertexLayout, PyInitialGenerator, PyMandelstamTDistribution,
-            PyParticleSpecies, PyReconstruction, PyStableGenerator,
+            PyParticleSpecies, PyReconstruction, PyRejectionEnvelope, PyRejectionSampleIter,
+            PyRejectionSamplingDiagnostics, PyStableGenerator,
         },
         get_threads,
         math::PyHistogram,

--- a/py-laddu-mpi/pyproject.toml
+++ b/py-laddu-mpi/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dynamic = ["version", "license", "description", "readme"]
 dependencies = [
   "numpy",
-  "ganesh-rs == 0.27.0",
+  "ganesh-rs == 0.27.1",
 ]
 
 [project.urls]

--- a/py-laddu/docs/source/tutorials/binned_fit.rst
+++ b/py-laddu/docs/source/tutorials/binned_fit.rst
@@ -55,7 +55,7 @@ where the terms with particle names in square brackets still represent the produ
    reaction = ld.Reaction.two_to_two(beam, target, kk, proton)
    decay = reaction.decay('kk')
    angles = decay.angles('kshort1')
-   polarization = reaction.polarization('pol_magnitude', 'pol_angle')
+   polarization = reaction.polarization(pol_magnitude='pol_magnitude', pol_angle='pol_angle')
 
    z00p = ld.Zlm("Z00+", l=0, m=0, r="+", angles=angles, polarization=polarization)
    z22p = ld.Zlm("Z22+", l=2, m=2, r="+", angles=angles, polarization=polarization)

--- a/py-laddu/docs/source/tutorials/unbinned_fit.rst
+++ b/py-laddu/docs/source/tutorials/unbinned_fit.rst
@@ -128,7 +128,7 @@ where :math:`BW_{L}(m, m_\alpha, \Gamma_\alpha)` is the Breit-Wigner amplitude f
 
 .. code:: python
 
-   polarization = reaction.polarization('pol_magnitude', 'pol_angle')
+   polarization = reaction.polarization(pol_magnitude='pol_magnitude', pol_angle='pol_angle')
 
 Next, we can create ``Zlm`` amplitudes:
 

--- a/py-laddu/examples/example_1/example_1.py
+++ b/py-laddu/examples/example_1/example_1.py
@@ -52,7 +52,7 @@ def reaction_variables() -> tuple[ld.Mass, ld.Angles, ld.Polarization]:
     return (
         decay.parent_mass(),
         decay.angles('kshort1'),
-        reaction.polarization('pol_magnitude', 'pol_angle'),
+        reaction.polarization(pol_magnitude='pol_magnitude', pol_angle='pol_angle'),
     )
 
 

--- a/py-laddu/examples/example_2/example_2.py
+++ b/py-laddu/examples/example_2/example_2.py
@@ -42,7 +42,9 @@ def reaction_variables() -> tuple[ld.Angles, ld.Polarization]:
     proton = ld.Particle.stored('proton')
     reaction = ld.Reaction.two_to_two(beam, target, kk, proton)
     angles = reaction.decay('kk').angles('kshort1')
-    polarization = reaction.polarization('pol_magnitude', 'pol_angle')
+    polarization = reaction.polarization(
+        pol_magnitude='pol_magnitude', pol_angle='pol_angle'
+    )
     return angles, polarization
 
 

--- a/py-laddu/examples/example_production_vertex/example_production_vertex.py
+++ b/py-laddu/examples/example_production_vertex/example_production_vertex.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "ganesh-rs",
+#     "laddu",
+#     "matplotlib",
+#     "numpy",
+#     "tqdm",
+# ]
+# ///
+"""Compare mass-binned Zlm and explicit production-vertex fits."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+
+import ganesh
+import laddu as ld
+import matplotlib.pyplot as plt
+import numpy as np
+from tqdm import trange
+
+P4_COLUMNS = ['beam', 'proton', 'kshort1', 'kshort2']
+AUX_COLUMNS = ['pol_magnitude', 'pol_angle']
+FRAME = 'GottfriedJackson'
+PHOTON_HELICITIES = (-1, 1)
+K_SECTORS = (0, 1)
+PRODUCTION_SPIN_SECTORS = (
+    (Fraction(1, 2), Fraction(1, 2)),
+    (Fraction(-1, 2), Fraction(-1, 2)),
+)
+PHOTON = ld.ParticleProperties('gamma', spin=1)
+PROTON = ld.ParticleProperties('proton', spin=Fraction(1, 2))
+KSHORT = ld.ParticleProperties('K_S', spin=0)
+
+
+def RESONANCE(spin: int) -> ld.ParticleProperties:
+    return ld.ParticleProperties(f'X{spin}', spin=spin)
+
+
+REACTION = ld.Reaction.two_to_two(
+    ld.Particle.stored('beam'),
+    ld.Particle.missing('target'),
+    ld.Particle.composite(
+        'kk', (ld.Particle.stored('kshort1'), ld.Particle.stored('kshort2'))
+    ),
+    ld.Particle.stored('proton'),
+)
+PRODUCTION = REACTION.production()
+DECAY = REACTION.decay('kk')
+POLARIZATION = REACTION.polarization(pol_magnitude='pol_magnitude', pol_angle='pol_angle')
+MASS = REACTION.mass('kk')
+
+
+@dataclass(frozen=True)
+class DecayWave:
+    label: str
+    j: int
+    m: int
+    l: int
+
+
+def decay_wave(label: str, *, j: int, m: int) -> DecayWave:
+    allowed_waves = ld.allowed_partial_waves(
+        RESONANCE(j),
+        KSHORT,
+        KSHORT,
+        max_l=j,
+        rules=ld.RuleSet.angular(),
+    )
+    return DecayWave(label, j=j, m=m, l=allowed_waves[0].wave.l)
+
+
+WAVES: list[DecayWave] = [decay_wave('S0', j=0, m=0), decay_wave('D2', j=2, m=2)]
+
+
+def complex_coupling(
+    name: str,
+    *tags: str,
+    anchor: bool = False,
+) -> ld.Expression:
+    re = ld.parameter(f'{name}_re', initial=1.0)
+    im = ld.parameter(f'{name}_im', initial=0.0)
+    coupling = ld.ComplexScalar(*tags, re=re, im=im)
+    if anchor:
+        coupling.fix_parameter(f'{name}_im', 0.0)
+    return coupling
+
+
+def allowed_production_waves(
+    decay_wave: DecayWave,
+    max_l: int,
+) -> list[ld.PartialWave]:
+    waves = []
+    for j_initial in ld.coupled_spins(PHOTON.spin, PROTON.spin):  # ty: ignore
+        parent = ld.ParticleProperties(f'gamma_p_J{j_initial}', spin=j_initial)
+        allowed_waves = ld.allowed_partial_waves(
+            parent,
+            RESONANCE(decay_wave.j),
+            PROTON,
+            max_l=max_l,
+            rules=ld.RuleSet.angular(),
+        )
+        waves.extend([allowed.wave for allowed in allowed_waves])
+    return waves
+
+
+def decay_factor(decay_wave: DecayWave) -> ld.Expression:
+    return DECAY.canonical_factor(
+        spin=decay_wave.j,
+        projection=decay_wave.m,
+        orbital_l=decay_wave.l,
+        coupled_spin=0,
+        daughter='kshort1',
+        daughter_1_spin=KSHORT.spin,  # ty: ignore
+        daughter_2_spin=KSHORT.spin,  # ty: ignore
+        lambda_1=0,
+        lambda_2=0,
+        frame=FRAME,
+    )
+
+
+def production_factor(
+    photon_helicity: int,
+    target_spin: Fraction,
+    recoil_spin: Fraction,
+    decay_wave: DecayWave,
+    production_wave: ld.PartialWave,
+) -> ld.Expression | None:
+    projection = photon_helicity + target_spin
+    lambda_total = decay_wave.m - recoil_spin
+    if abs(projection) > production_wave.j or abs(lambda_total) > production_wave.j:
+        return None
+    return PRODUCTION.canonical_factor(
+        spin=production_wave.j,
+        projection=projection,
+        orbital_l=production_wave.l,
+        coupled_spin=production_wave.s,
+        produced_spin=decay_wave.j,
+        recoil_spin=PROTON.spin,  # ty: ignore
+        lambda_produced=decay_wave.m,
+        lambda_recoil=recoil_spin,
+        frame=FRAME,
+    )
+
+
+def helicity_parameter_name(
+    decay_wave: DecayWave,
+    photon_helicity: int,
+) -> str:
+    return f'T_{decay_wave.label}_h{photon_helicity}'
+
+
+def decay_waves_for_helicity(photon_helicity: int) -> list[DecayWave]:
+    waves = []
+    for wave in WAVES:
+        m = wave.m if photon_helicity == 1 else -wave.m
+        waves.append(DecayWave(wave.label, wave.j, m, wave.l))
+    return waves
+
+
+def production_amplitudes(
+    target_spin: Fraction,
+    recoil_spin: Fraction,
+    max_l: int,
+) -> dict[int, ld.Expression]:
+    amplitudes = {}
+    for helicity in PHOTON_HELICITIES:
+        terms = []
+        for decay_wave in decay_waves_for_helicity(helicity):
+            decay = decay_factor(decay_wave)
+            for production_wave in allowed_production_waves(decay_wave, max_l):
+                prod = production_factor(
+                    helicity,
+                    target_spin,
+                    recoil_spin,
+                    decay_wave,
+                    production_wave,
+                )
+                if prod is None:
+                    continue
+                coupling = complex_coupling(
+                    helicity_parameter_name(decay_wave, helicity),
+                    decay_wave.label,
+                    anchor=decay_wave.label == 'S0',
+                )
+                terms.append(coupling * prod * decay)
+        amplitudes[helicity] = ld.expr_sum(terms) if terms else ld.Zero()
+    return amplitudes
+
+
+def full_physics_model(max_l: int = 0) -> ld.Expression:
+    terms = []
+    for target_spin, recoil_spin in PRODUCTION_SPIN_SECTORS:
+        amps = production_amplitudes(
+            target_spin,
+            recoil_spin,
+            max_l,
+        )
+        for helicity in PHOTON_HELICITIES:
+            for helicity_prime in PHOTON_HELICITIES:
+                rho = ld.PhotonSDME(
+                    helicity=helicity,
+                    helicity_prime=helicity_prime,
+                    polarization=POLARIZATION,
+                )
+                terms.append((rho * amps[helicity] * amps[helicity_prime].conj()).real())
+    return ld.expr_sum(terms)
+
+
+def helicity_t_parameter_name(
+    wave: DecayWave,
+    photon_helicity: int,
+) -> str:
+    return f'T_{wave.label}_h{photon_helicity}_m{wave.m}'
+
+
+def helicity_t_model() -> ld.Expression:
+    angles = DECAY.angles('kshort1', FRAME)
+    terms = []
+    for _ in K_SECTORS:
+        amps = {}
+        for helicity in PHOTON_HELICITIES:
+            amp_terms = []
+            for wave in WAVES:
+                m = wave.m if helicity == 1 else -wave.m
+                ylm = ld.Ylm(
+                    l=wave.j,
+                    m=m,
+                    angles=angles,
+                )
+                t_wave = DecayWave(wave.label, wave.j, m, wave.l)
+                coupling = complex_coupling(
+                    helicity_t_parameter_name(t_wave, helicity),
+                    wave.label,
+                    anchor=wave.label == 'S0',
+                )
+                amp_terms.append(coupling * ylm)
+            amps[helicity] = ld.expr_sum(amp_terms)
+
+        for helicity in PHOTON_HELICITIES:
+            for helicity_prime in PHOTON_HELICITIES:
+                rho = ld.PhotonSDME(
+                    helicity=helicity,
+                    helicity_prime=helicity_prime,
+                    polarization=POLARIZATION,
+                )
+                terms.append((rho * amps[helicity] * amps[helicity_prime].conj()).real())
+    return ld.expr_sum(terms)
+
+
+def zlm_parameter_name(wave: DecayWave, reflectivity: str) -> str:
+    return f'Z_{wave.label}_{reflectivity}'
+
+
+def zlm_model() -> ld.Expression:
+    angles = DECAY.angles('kshort1', FRAME)
+    sectors = []
+    for _ in K_SECTORS:
+        for reflectivity in ('+', '-'):
+            real_terms = []
+            imag_terms = []
+            for wave in WAVES:
+                zlm = ld.Zlm(
+                    l=wave.j,
+                    m=wave.m,
+                    r=reflectivity,
+                    angles=angles,
+                    polarization=POLARIZATION,
+                )
+                coupling = complex_coupling(
+                    zlm_parameter_name(wave, reflectivity),
+                    wave.label,
+                    f'{wave.label}{reflectivity}',
+                    anchor=wave.label == 'S0',
+                )
+                real_terms.append(coupling * zlm.real())
+                imag_terms.append(coupling * zlm.imag())
+            sectors.append(
+                ld.expr_sum(real_terms).norm_sqr() + ld.expr_sum(imag_terms).norm_sqr()
+            )
+    return ld.expr_sum(sectors)
+
+
+def best_fit(
+    model: ld.Expression, data: ld.Dataset, accmc: ld.Dataset, niters: int
+) -> tuple[ld.NLL, ganesh.MinimizationSummary]:
+    nll = ld.NLL(model, data, accmc)
+    rng = np.random.default_rng(0)
+    best = None
+    best_fx = np.inf
+    for _ in range(niters):
+        p0 = rng.normal(0.0, 10.0, len(nll.parameters.free))
+        fit = nll.minimize(p0)
+        if fit.fx < best_fx:
+            best = fit
+            best_fx = fit.fx
+    if best is None:
+        msg = 'all fit attempts failed'
+        raise RuntimeError(msg)
+    return nll, best
+
+
+def project_fit_counts(
+    nll: ld.NLL,
+    fit: ganesh.MinimizationSummary,
+) -> dict[str, float]:
+    weights = nll.project_weights(
+        fit.x,
+        subsets=[None, ['S0'], ['D2']],
+        strict=True,
+    )
+    return {
+        'total': float(weights[0].sum()),
+        'S0': float(weights[1].sum()),
+        'D2': float(weights[2].sum()),
+    }
+
+
+def print_fit_quality(rows: list[dict[str, float]]) -> None:
+    print('\nFit quality')
+    print(
+        'bin  mass range       zlm NLL        helicity-T NLL  production NLL  '
+        'Delta T    Delta prod'
+    )
+    for row in rows:
+        print(
+            f'{int(row["bin"]):>3}  '
+            f'{row["mass_low"]:.3f}-{row["mass_high"]:.3f}  '
+            f'{row["zlm_nll"]:>13.6g}  '
+            f'{row["helicity_t_nll"]:>14.6g}  '
+            f'{row["production_nll"]:>14.6g}  '
+            f'{row["helicity_t_delta_nll"]:>8.3g}  '
+            f'{row["production_delta_nll"]:>10.3g}'
+        )
+
+
+def print_projection_summary(rows: list[dict[str, float | str]]) -> None:
+    print('\nProjected wave yields')
+    print('bin  component  data       zlm        helicity-T  production')
+    by_bin_component: dict[tuple[int, str], dict[str, float | str]] = {}
+    for row in rows:
+        key = (int(row['bin']), str(row['component']))
+        entry = by_bin_component.setdefault(
+            key,
+            {
+                'bin': int(row['bin']),
+                'component': str(row['component']),
+                'data_count': float(row['data_count']),
+            },
+        )
+        entry[str(row['model'])] = float(row['projected_count'])
+    component_order = {'total': 0, 'S0': 1, 'D2': 2}
+    for key in sorted(
+        by_bin_component, key=lambda item: (item[0], component_order[item[1]])
+    ):
+        row = by_bin_component[key]
+        zlm = float(row.get('zlm', float('nan')))
+        helicity_t = float(row.get('helicity_t', float('nan')))
+        production = float(row.get('production', float('nan')))
+        print(
+            f'{int(row["bin"]):>3}  '
+            f'{row["component"]!s:<9}  '
+            f'{row["data_count"]:>7.0f}  '
+            f'{zlm:>9.3g}  '
+            f'{helicity_t:>10.3g}  '
+            f'{production:>10.3g}'
+        )
+
+
+def plot_wave_projections(
+    rows: list[dict[str, float | str]],
+    output_path: Path,
+    data_counts: np.ndarray,
+    mass_edges: np.ndarray,
+) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    models = ['zlm', 'helicity_t', 'production']
+    components = [
+        ('total', 'total'),
+        ('S0', 'S0'),
+        ('D2', 'D2'),
+    ]
+    _, axes = plt.subplots(
+        1,
+        3,
+        figsize=(13, 4),
+        sharex=True,
+    )
+    axes_flat = np.ravel(axes)
+    offsets = {'zlm': -0.006, 'helicity_t': 0.0, 'production': 0.006}
+    colors = {
+        'zlm': '#000000',
+        'helicity_t': '#0072B2',
+        'production': '#D55E00',
+    }
+    for ax, (component, title) in zip(axes_flat, components, strict=False):
+        ax.stairs(data_counts, mass_edges, color='#555555', label='data')
+        for model in models:
+            points = sorted(
+                (
+                    row
+                    for row in rows
+                    if row['component'] == component and row['model'] == model
+                ),
+                key=lambda row: float(row['mass_center']),
+            )
+            ax.scatter(
+                [float(row['mass_center']) + offsets[model] for row in points],
+                [float(row['projected_count']) for row in points],
+                color=colors[model],
+                label=model,
+                s=28,
+            )
+        ax.set_title(title)
+        ax.set_ylabel('projected counts')
+        ax.grid(alpha=0.3)
+    for ax in axes_flat:
+        ax.set_xlabel(r'$m(K_S K_S)$ [GeV]')
+    axes_flat[0].legend()
+    plt.tight_layout()
+    plt.savefig(output_path)
+    plt.close()
+
+
+def fit_bins(
+    nbins: int,
+    niters: int,
+    *,
+    plot_path: Path | None = None,
+) -> None:
+    script_dir = Path(os.path.realpath(__file__)).parent.resolve()
+    data_dir = script_dir.parent / 'data'
+    data = ld.io.read_parquet(data_dir / 'data.parquet', p4s=P4_COLUMNS, aux=AUX_COLUMNS)
+    accmc = ld.io.read_parquet(
+        data_dir / 'accmc.parquet', p4s=P4_COLUMNS, aux=AUX_COLUMNS
+    )
+    mass_range = (1.0, 2.0)
+    data_masses = MASS.value_on(data)
+    data_counts, mass_edges = np.histogram(data_masses, bins=nbins, range=mass_range)
+    data_bins = data.bin_by(MASS, nbins, (1.0, 2.0))
+    accmc_bins = accmc.bin_by(MASS, nbins, (1.0, 2.0))
+    z_model = zlm_model()
+    t_model = helicity_t_model()
+    production_model = full_physics_model()
+    fit_rows = []
+    projection_rows = []
+    for ibin in trange(nbins):
+        mass_low = 1.0 + ibin / nbins
+        mass_high = 1.0 + (ibin + 1) / nbins
+        mass_center = 0.5 * (mass_low + mass_high)
+        z_nll, z_fit = best_fit(z_model, data_bins[ibin], accmc_bins[ibin], niters)
+        t_nll, t_fit = best_fit(t_model, data_bins[ibin], accmc_bins[ibin], niters)
+        prod_nll, prod_fit = best_fit(
+            production_model, data_bins[ibin], accmc_bins[ibin], niters
+        )
+        fit_rows.append(
+            {
+                'bin': ibin,
+                'mass_low': mass_low,
+                'mass_high': mass_high,
+                'zlm_nll': z_fit.fx,
+                'helicity_t_nll': t_fit.fx,
+                'production_nll': prod_fit.fx,
+                'helicity_t_delta_nll': t_fit.fx - z_fit.fx,
+                'production_delta_nll': prod_fit.fx - z_fit.fx,
+            }
+        )
+        projections_by_model = {
+            'zlm': project_fit_counts(z_nll, z_fit),
+            'helicity_t': project_fit_counts(t_nll, t_fit),
+            'production': project_fit_counts(prod_nll, prod_fit),
+        }
+        for model_name, projections in projections_by_model.items():
+            for component, projected_count in projections.items():
+                reference = projections_by_model['zlm'][component]
+                projection_rows.append(
+                    {
+                        'bin': ibin,
+                        'mass_center': mass_center,
+                        'model': model_name,
+                        'component': component,
+                        'projected_count': projected_count,
+                        'delta_from_zlm': projected_count - reference,
+                        'data_count': int(data_counts[ibin]),
+                    }
+                )
+    print_fit_quality(fit_rows)
+    print_projection_summary(projection_rows)
+    if plot_path is not None:
+        plot_wave_projections(projection_rows, plot_path, data_counts, mass_edges)
+        print(f'\nWrote plot to {plot_path}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-n', '--nbins', type=int, default=4)
+    parser.add_argument('-i', '--niters', type=int, default=3)
+    parser.add_argument(
+        '--plot',
+        type=Path,
+        default=Path('production_vertex_projections.svg'),
+        help='SVG path for the wave projection plot. Use "none" to disable.',
+    )
+    args = parser.parse_args()
+    plot_path = None if str(args.plot).lower() == 'none' else args.plot
+    fit_bins(args.nbins, args.niters, plot_path=plot_path)

--- a/py-laddu/examples/example_production_vertex/production_vertex_projections.svg
+++ b/py-laddu/examples/example_production_vertex/production_vertex_projections.svg
@@ -1,0 +1,2466 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="936pt" height="288pt" viewBox="0 0 936 288" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-05-20T16:27:58.094073</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 288 
+L 936 288 
+L 936 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 63.47 244.024 
+L 308.4 244.024 
+L 308.4 26.88 
+L 63.47 26.88 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 74.603182 244.024 
+L 74.603182 243.426447 
+L 82.025303 243.426447 
+L 82.025303 243.224457 
+L 89.447424 243.224457 
+L 89.447424 242.879392 
+L 96.869545 242.879392 
+L 96.869545 242.610072 
+L 104.291667 242.610072 
+L 104.291667 241.692702 
+L 111.713788 241.692702 
+L 111.713788 241.347636 
+L 119.135909 241.347636 
+L 119.135909 240.001038 
+L 126.55803 240.001038 
+L 126.55803 238.982673 
+L 133.980152 238.982673 
+L 133.980152 236.802868 
+L 141.402273 236.802868 
+L 141.402273 234.370575 
+L 148.824394 234.370575 
+L 148.824394 229.539654 
+L 156.246515 229.539654 
+L 156.246515 221.106584 
+L 163.668636 221.106584 
+L 163.668636 205.620706 
+L 171.090758 205.620706 
+L 171.090758 170.77748 
+L 178.512879 170.77748 
+L 178.512879 96.16753 
+L 185.935 96.16753 
+L 185.935 37.220199 
+L 193.357121 37.220199 
+L 193.357121 112.486616 
+L 200.779242 112.486616 
+L 200.779242 179.454622 
+L 208.201364 179.454622 
+L 208.201364 208.978785 
+L 215.623485 208.978785 
+L 215.623485 222.596258 
+L 223.045606 222.596258 
+L 223.045606 230.726344 
+L 230.467727 230.726344 
+L 230.467727 234.40424 
+L 237.889848 234.40424 
+L 237.889848 237.509832 
+L 245.31197 237.509832 
+L 245.31197 238.334623 
+L 252.734091 238.334623 
+L 252.734091 239.992622 
+L 260.156212 239.992622 
+L 260.156212 240.901576 
+L 267.578333 240.901576 
+L 267.578333 241.372885 
+L 275.000455 241.372885 
+L 275.000455 241.886276 
+L 282.422576 241.886276 
+L 282.422576 242.138763 
+L 289.844697 242.138763 
+L 289.844697 242.618488 
+L 297.266818 242.618488 
+L 297.266818 244.024 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #555555; stroke-linejoin: miter"/>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path id="m692a20c39d" d="M 0 2.645751 
+C 0.701661 2.645751 1.374679 2.366978 1.870829 1.870829 
+C 2.366978 1.374679 2.645751 0.701661 2.645751 0 
+C 2.645751 -0.701661 2.366978 -1.374679 1.870829 -1.870829 
+C 1.374679 -2.366978 0.701661 -2.645751 0 -2.645751 
+C -0.701661 -2.645751 -1.374679 -2.366978 -1.870829 -1.870829 
+C -2.366978 -1.374679 -2.645751 -0.701661 -2.645751 0 
+C -2.645751 0.701661 -2.366978 1.374679 -1.870829 1.870829 
+C -1.374679 2.366978 -0.701661 2.645751 0 2.645751 
+z
+" style="stroke: #000000"/>
+    </defs>
+    <g clip-path="url(#p7076341611)">
+     <use xlink:href="#m692a20c39d" x="76.978261" y="243.426447" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="84.400382" y="243.224458" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="91.822503" y="242.879392" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="99.244624" y="242.610072" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="106.666745" y="241.692702" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="114.088867" y="241.347636" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="121.510988" y="240.001038" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="128.933109" y="238.982674" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="136.35523" y="236.802868" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="143.777352" y="234.370575" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="151.199473" y="229.539655" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="158.621594" y="221.106584" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="166.043715" y="205.620704" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="173.465836" y="170.777476" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="180.887958" y="96.16753" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="188.310079" y="37.2202" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="195.7322" y="112.486615" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="203.154321" y="179.45462" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="210.576442" y="208.978785" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="217.998564" y="222.596257" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="225.420685" y="230.726341" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="232.842806" y="234.40424" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="240.264927" y="237.509833" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="247.687048" y="238.334624" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="255.10917" y="239.992622" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="262.531291" y="240.901576" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="269.953412" y="241.372884" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="277.375533" y="241.886275" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="284.797655" y="242.138762" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="292.219776" y="242.618488" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="PathCollection_2">
+    <defs>
+     <path id="m929e2037a8" d="M 0 2.645751 
+C 0.701661 2.645751 1.374679 2.366978 1.870829 1.870829 
+C 2.366978 1.374679 2.645751 0.701661 2.645751 0 
+C 2.645751 -0.701661 2.366978 -1.374679 1.870829 -1.870829 
+C 1.374679 -2.366978 0.701661 -2.645751 0 -2.645751 
+C -0.701661 -2.645751 -1.374679 -2.366978 -1.870829 -1.870829 
+C -2.366978 -1.374679 -2.645751 -0.701661 -2.645751 0 
+C -2.645751 0.701661 -2.366978 1.374679 -1.870829 1.870829 
+C -1.374679 2.366978 -0.701661 2.645751 0 2.645751 
+z
+" style="stroke: #0072b2"/>
+    </defs>
+    <g clip-path="url(#p7076341611)">
+     <use xlink:href="#m929e2037a8" x="78.314242" y="243.426447" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="85.736364" y="243.224458" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="93.158485" y="242.879392" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="100.580606" y="242.610071" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="108.002727" y="241.692702" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="115.424848" y="241.347636" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="122.84697" y="240.001038" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="130.269091" y="238.982674" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="137.691212" y="236.802868" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="145.113333" y="234.370574" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="152.535455" y="229.539655" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="159.957576" y="221.106584" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="167.379697" y="205.620706" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="174.801818" y="170.77748" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="182.223939" y="96.167532" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="189.646061" y="37.22019" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="197.068182" y="112.486617" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="204.490303" y="179.454622" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="211.912424" y="208.978787" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="219.334545" y="222.596258" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="226.756667" y="230.726344" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="234.178788" y="234.40424" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="241.600909" y="237.509832" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="249.02303" y="238.334623" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="256.445152" y="239.992622" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="263.867273" y="240.901572" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="271.289394" y="241.372886" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="278.711515" y="241.886276" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="286.133636" y="242.138762" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="293.555758" y="242.618488" style="fill: #0072b2; stroke: #0072b2"/>
+    </g>
+   </g>
+   <g id="PathCollection_3">
+    <defs>
+     <path id="mf19d001b8d" d="M 0 2.645751 
+C 0.701661 2.645751 1.374679 2.366978 1.870829 1.870829 
+C 2.366978 1.374679 2.645751 0.701661 2.645751 0 
+C 2.645751 -0.701661 2.366978 -1.374679 1.870829 -1.870829 
+C 1.374679 -2.366978 0.701661 -2.645751 0 -2.645751 
+C -0.701661 -2.645751 -1.374679 -2.366978 -1.870829 -1.870829 
+C -2.366978 -1.374679 -2.645751 -0.701661 -2.645751 0 
+C -2.645751 0.701661 -2.366978 1.374679 -1.870829 1.870829 
+C -1.374679 2.366978 -0.701661 2.645751 0 2.645751 
+z
+" style="stroke: #d55e00"/>
+    </defs>
+    <g clip-path="url(#p7076341611)">
+     <use xlink:href="#mf19d001b8d" x="79.650224" y="243.426447" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="87.072345" y="243.224457" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="94.494467" y="242.879392" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="101.916588" y="242.610072" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="109.338709" y="241.692703" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="116.76083" y="241.347636" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="124.182952" y="240.001038" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="131.605073" y="238.982673" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="139.027194" y="236.802868" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="146.449315" y="234.370575" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="153.871436" y="229.539655" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="161.293558" y="221.106584" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="168.715679" y="205.620706" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="176.1378" y="170.77748" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="183.559921" y="96.16753" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="190.982042" y="37.220199" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="198.404164" y="112.48662" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="205.826285" y="179.454626" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="213.248406" y="208.978785" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="220.670527" y="222.596258" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="228.092648" y="230.726344" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="235.51477" y="234.40424" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="242.936891" y="237.509832" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="250.359012" y="238.334623" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="257.781133" y="239.992622" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="265.203255" y="240.901576" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="272.625376" y="241.372885" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="280.047497" y="241.886275" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="287.469618" y="242.138763" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="294.891739" y="242.618488" style="fill: #d55e00; stroke: #d55e00"/>
+    </g>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 74.603182 244.024 
+L 74.603182 26.88 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m42655b2cbf" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m42655b2cbf" x="74.603182" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 1.0 -->
+      <g transform="translate(66.651619 258.622437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 119.135909 244.024 
+L 119.135909 26.88 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="119.135909" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1.2 -->
+      <g transform="translate(111.184347 258.622437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 163.668636 244.024 
+L 163.668636 26.88 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="163.668636" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 1.4 -->
+      <g transform="translate(155.717074 258.622437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 208.201364 244.024 
+L 208.201364 26.88 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="208.201364" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 1.6 -->
+      <g transform="translate(200.249801 258.622437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 252.734091 244.024 
+L 252.734091 26.88 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="252.734091" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1.8 -->
+      <g transform="translate(244.782528 258.622437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 297.266818 244.024 
+L 297.266818 26.88 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="297.266818" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 2.0 -->
+      <g transform="translate(289.315256 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- $m(K_S K_S)$ [GeV] -->
+     <g transform="translate(149.985 272.300563) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-Oblique-6d" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Oblique-4b" d="M 1081 4666 
+L 1716 4666 
+L 1331 2700 
+L 3781 4666 
+L 4622 4666 
+L 1850 2438 
+L 3878 0 
+L 3109 0 
+L 1247 2272 
+L 806 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-Oblique-53" d="M 3859 4513 
+L 3738 3897 
+Q 3422 4066 3111 4152 
+Q 2800 4238 2509 4238 
+Q 1944 4238 1609 3991 
+Q 1275 3744 1275 3334 
+Q 1275 3109 1398 2989 
+Q 1522 2869 2034 2731 
+L 2413 2638 
+Q 3053 2472 3303 2217 
+Q 3553 1963 3553 1503 
+Q 3553 797 2998 353 
+Q 2444 -91 1538 -91 
+Q 1166 -91 791 -17 
+Q 416 56 38 206 
+L 166 856 
+Q 513 641 861 531 
+Q 1209 422 1556 422 
+Q 2147 422 2503 684 
+Q 2859 947 2859 1369 
+Q 2859 1650 2717 1795 
+Q 2575 1941 2106 2059 
+L 1728 2156 
+Q 1081 2325 845 2545 
+Q 609 2766 609 3163 
+Q 609 3859 1145 4304 
+Q 1681 4750 2541 4750 
+Q 2875 4750 3203 4690 
+Q 3531 4631 3859 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(0 0.015625)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(97.412109 0.015625)"/>
+      <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(136.425781 0.015625)"/>
+      <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(202.001953 -16.390625) scale(0.7)"/>
+      <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(249.169922 0.015625)"/>
+      <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(314.746094 -16.390625) scale(0.7)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(361.914062 0.015625)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(400.927734 0.015625)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(432.714844 0.015625)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(471.728516 0.015625)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(549.21875 0.015625)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(610.742188 0.015625)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(679.150391 0.015625)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_13">
+      <path d="M 63.47 244.024 
+L 308.4 244.024 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <defs>
+       <path id="m4a9e6bd7f6" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="63.47" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(50.1075 247.823219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_15">
+      <path d="M 63.47 201.94281 
+L 308.4 201.94281 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="63.47" y="201.94281" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 5000 -->
+      <g transform="translate(31.02 205.742029) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_17">
+      <path d="M 63.47 159.86162 
+L 308.4 159.86162 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="63.47" y="159.86162" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 10000 -->
+      <g transform="translate(24.6575 163.660839) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_19">
+      <path d="M 63.47 117.78043 
+L 308.4 117.78043 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="63.47" y="117.78043" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 15000 -->
+      <g transform="translate(24.6575 121.579648) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_21">
+      <path d="M 63.47 75.69924 
+L 308.4 75.69924 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="63.47" y="75.69924" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 20000 -->
+      <g transform="translate(24.6575 79.498458) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_23">
+      <path d="M 63.47 33.618049 
+L 308.4 33.618049 
+" clip-path="url(#p7076341611)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="63.47" y="33.618049" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 25000 -->
+      <g transform="translate(24.6575 37.417268) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- projected counts -->
+     <g transform="translate(18.577812 177.354344) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6a" d="M 603 3500 
+L 1178 3500 
+L 1178 -63 
+Q 1178 -731 923 -1031 
+Q 669 -1331 103 -1331 
+L -116 -1331 
+L -116 -844 
+L 38 -844 
+Q 366 -844 484 -692 
+Q 603 -541 603 -63 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(102.339844 0)"/>
+      <use xlink:href="#DejaVuSans-6a" transform="translate(163.521484 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(191.304688 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(252.828125 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(307.808594 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(347.017578 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(408.541016 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(472.017578 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(503.804688 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(558.785156 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(619.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(683.345703 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(746.724609 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(785.933594 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 63.47 244.024 
+L 63.47 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 308.4 244.024 
+L 308.4 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 63.47 244.024 
+L 308.4 244.024 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 63.47 26.88 
+L 308.4 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- total -->
+    <g transform="translate(172.215625 20.88) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-74"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(39.208984 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(100.390625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(139.599609 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(200.878906 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 215.707813 93.870625 
+L 301.4 93.870625 
+Q 303.4 93.870625 303.4 91.870625 
+L 303.4 33.88 
+Q 303.4 31.88 301.4 31.88 
+L 215.707813 31.88 
+Q 213.707813 31.88 213.707813 33.88 
+L 213.707813 91.870625 
+Q 213.707813 93.870625 215.707813 93.870625 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_25">
+     <path d="M 217.707813 39.978437 
+L 237.707813 39.978437 
+" style="fill: none; stroke: #555555; stroke-linecap: square"/>
+    </g>
+    <g id="text_16">
+     <!-- data -->
+     <g transform="translate(245.707813 43.478437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(124.755859 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(163.964844 0)"/>
+     </g>
+    </g>
+    <g id="PathCollection_4">
+     <g>
+      <use xlink:href="#m692a20c39d" x="227.707813" y="55.531562" style="stroke: #000000"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- zlm -->
+     <g transform="translate(245.707813 58.156562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-7a"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(52.490234 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(80.273438 0)"/>
+     </g>
+    </g>
+    <g id="PathCollection_5">
+     <g>
+      <use xlink:href="#m929e2037a8" x="227.707813" y="70.209687" style="fill: #0072b2; stroke: #0072b2"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- helicity_t -->
+     <g transform="translate(245.707813 72.834687) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-68"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.378906 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(124.902344 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(152.685547 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(180.46875 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(235.449219 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(263.232422 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(302.441406 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(361.621094 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(411.621094 0)"/>
+     </g>
+    </g>
+    <g id="PathCollection_6">
+     <g>
+      <use xlink:href="#mf19d001b8d" x="227.707813" y="85.165937" style="fill: #d55e00; stroke: #d55e00"/>
+     </g>
+    </g>
+    <g id="text_19">
+     <!-- production -->
+     <g transform="translate(245.707813 87.790937) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(102.339844 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(163.521484 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(226.998047 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(290.376953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(345.357422 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(384.566406 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(412.349609 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(473.53125 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_9">
+    <path d="M 371.87 244.024 
+L 616.8 244.024 
+L 616.8 26.88 
+L 371.87 26.88 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 383.003182 244.024 
+L 383.003182 243.426447 
+L 390.425303 243.426447 
+L 390.425303 243.224457 
+L 397.847424 243.224457 
+L 397.847424 242.879392 
+L 405.269545 242.879392 
+L 405.269545 242.610072 
+L 412.691667 242.610072 
+L 412.691667 241.692702 
+L 420.113788 241.692702 
+L 420.113788 241.347636 
+L 427.535909 241.347636 
+L 427.535909 240.001038 
+L 434.95803 240.001038 
+L 434.95803 238.982673 
+L 442.380152 238.982673 
+L 442.380152 236.802867 
+L 449.802273 236.802867 
+L 449.802273 234.370575 
+L 457.224394 234.370575 
+L 457.224394 229.539654 
+L 464.646515 229.539654 
+L 464.646515 221.106583 
+L 472.068636 221.106583 
+L 472.068636 205.620704 
+L 479.490758 205.620704 
+L 479.490758 170.777477 
+L 486.912879 170.777477 
+L 486.912879 96.167524 
+L 494.335 96.167524 
+L 494.335 37.22019 
+L 501.757121 37.22019 
+L 501.757121 112.48661 
+L 509.179242 112.48661 
+L 509.179242 179.454619 
+L 516.601364 179.454619 
+L 516.601364 208.978783 
+L 524.023485 208.978783 
+L 524.023485 222.596257 
+L 531.445606 222.596257 
+L 531.445606 230.726343 
+L 538.867727 230.726343 
+L 538.867727 234.40424 
+L 546.289848 234.40424 
+L 546.289848 237.509831 
+L 553.71197 237.509831 
+L 553.71197 238.334623 
+L 561.134091 238.334623 
+L 561.134091 239.992622 
+L 568.556212 239.992622 
+L 568.556212 240.901576 
+L 575.978333 240.901576 
+L 575.978333 241.372885 
+L 583.400455 241.372885 
+L 583.400455 241.886275 
+L 590.822576 241.886275 
+L 590.822576 242.138763 
+L 598.244697 242.138763 
+L 598.244697 242.618488 
+L 605.666818 242.618488 
+L 605.666818 244.024 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #555555; stroke-linejoin: miter"/>
+   </g>
+   <g id="PathCollection_7">
+    <g clip-path="url(#p399594f309)">
+     <use xlink:href="#m692a20c39d" x="385.378261" y="243.442885" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="392.800382" y="243.27392" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="400.222503" y="242.932555" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="407.644624" y="242.753421" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="415.066745" y="242.36284" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="422.488867" y="241.710604" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="429.910988" y="240.452703" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="437.333109" y="239.851224" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="444.75523" y="237.823879" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="452.177352" y="236.332854" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="459.599473" y="232.599846" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="467.021594" y="226.79238" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="474.443715" y="215.571366" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="481.865836" y="191.871608" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="489.287958" y="142.424256" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="496.710079" y="111.801523" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="504.1322" y="162.702999" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="511.554321" y="204.224873" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="518.976442" y="222.302881" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="526.398564" y="230.81358" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="533.820685" y="236.14817" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="541.242806" y="238.122039" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="548.664927" y="240.107461" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="556.087048" y="240.434008" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="563.50917" y="241.640922" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="570.931291" y="242.391431" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="578.353412" y="242.691467" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="585.775533" y="243.012974" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="593.197655" y="242.957669" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="600.619776" y="243.300089" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="PathCollection_8">
+    <g clip-path="url(#p399594f309)">
+     <use xlink:href="#m929e2037a8" x="386.714242" y="243.445938" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="394.136364" y="243.27653" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="401.558485" y="242.934397" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="408.980606" y="242.751837" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="416.402727" y="242.348856" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="423.824848" y="241.705215" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="431.24697" y="240.45461" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="438.669091" y="239.676402" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="446.091212" y="237.73732" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="453.513333" y="235.501447" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="460.935455" y="231.393943" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="468.357576" y="225.52345" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="475.779697" y="214.551154" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="483.201818" y="189.204059" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="490.623939" y="139.144362" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="498.046061" y="115.019957" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="505.468182" y="165.614199" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="512.890303" y="205.602908" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="520.312424" y="223.637555" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="527.734545" y="231.495043" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="535.156667" y="236.486862" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="542.578788" y="238.270392" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="550.000909" y="240.335604" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="557.42303" y="240.379377" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="564.845152" y="241.664507" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="572.267273" y="242.429813" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="579.689394" y="242.726796" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="587.111515" y="243.060573" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="594.533636" y="242.976231" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="601.955758" y="243.316375" style="fill: #0072b2; stroke: #0072b2"/>
+    </g>
+   </g>
+   <g id="PathCollection_9">
+    <g clip-path="url(#p399594f309)">
+     <use xlink:href="#mf19d001b8d" x="388.050224" y="243.438618" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="395.472345" y="243.278505" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="402.894467" y="242.87958" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="410.316588" y="242.667069" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="417.738709" y="242.371823" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="425.16083" y="241.509217" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="432.582952" y="240.335036" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="440.005073" y="239.757796" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="447.427194" y="237.530246" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="454.849315" y="235.727862" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="462.271436" y="231.907513" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="469.693558" y="225.470368" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="477.115679" y="213.779045" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="484.5378" y="188.837829" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="491.959921" y="135.704483" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="499.382042" y="103.906145" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="506.804164" y="158.518231" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="514.226285" y="201.542108" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="521.648406" y="221.136138" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="529.070527" y="229.37349" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="536.492648" y="235.779354" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="543.91477" y="237.785592" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="551.336891" y="239.621563" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="558.759012" y="240.286138" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="566.181133" y="241.701103" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="573.603255" y="242.387717" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="581.025376" y="242.599262" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="588.447497" y="242.908607" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="595.869618" y="242.842775" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="603.291739" y="243.217363" style="fill: #d55e00; stroke: #d55e00"/>
+    </g>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_7">
+     <g id="line2d_26">
+      <path d="M 383.003182 244.024 
+L 383.003182 26.88 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="383.003182" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 1.0 -->
+      <g transform="translate(375.051619 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_28">
+      <path d="M 427.535909 244.024 
+L 427.535909 26.88 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="427.535909" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 1.2 -->
+      <g transform="translate(419.584347 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_30">
+      <path d="M 472.068636 244.024 
+L 472.068636 26.88 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="472.068636" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 1.4 -->
+      <g transform="translate(464.117074 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_32">
+      <path d="M 516.601364 244.024 
+L 516.601364 26.88 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="516.601364" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 1.6 -->
+      <g transform="translate(508.649801 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_34">
+      <path d="M 561.134091 244.024 
+L 561.134091 26.88 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="561.134091" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 1.8 -->
+      <g transform="translate(553.182528 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_36">
+      <path d="M 605.666818 244.024 
+L 605.666818 26.88 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="605.666818" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 2.0 -->
+      <g transform="translate(597.715256 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_26">
+     <!-- $m(K_S K_S)$ [GeV] -->
+     <g transform="translate(458.385 272.300563) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(0 0.015625)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(97.412109 0.015625)"/>
+      <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(136.425781 0.015625)"/>
+      <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(202.001953 -16.390625) scale(0.7)"/>
+      <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(249.169922 0.015625)"/>
+      <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(314.746094 -16.390625) scale(0.7)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(361.914062 0.015625)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(400.927734 0.015625)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(432.714844 0.015625)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(471.728516 0.015625)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(549.21875 0.015625)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(610.742188 0.015625)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(679.150391 0.015625)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_7">
+     <g id="line2d_38">
+      <path d="M 371.87 244.024 
+L 616.8 244.024 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="371.87" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 0 -->
+      <g transform="translate(358.5075 247.823219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_40">
+      <path d="M 371.87 201.942808 
+L 616.8 201.942808 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="371.87" y="201.942808" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 5000 -->
+      <g transform="translate(339.42 205.742027) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_42">
+      <path d="M 371.87 159.861616 
+L 616.8 159.861616 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="371.87" y="159.861616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 10000 -->
+      <g transform="translate(333.0575 163.660835) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_44">
+      <path d="M 371.87 117.780424 
+L 616.8 117.780424 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="371.87" y="117.780424" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 15000 -->
+      <g transform="translate(333.0575 121.579643) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_46">
+      <path d="M 371.87 75.699232 
+L 616.8 75.699232 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="371.87" y="75.699232" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 20000 -->
+      <g transform="translate(333.0575 79.498451) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_48">
+      <path d="M 371.87 33.61804 
+L 616.8 33.61804 
+" clip-path="url(#p399594f309)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="371.87" y="33.61804" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 25000 -->
+      <g transform="translate(333.0575 37.417259) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_33">
+     <!-- projected counts -->
+     <g transform="translate(326.977813 177.354344) rotate(-90) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(102.339844 0)"/>
+      <use xlink:href="#DejaVuSans-6a" transform="translate(163.521484 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(191.304688 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(252.828125 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(307.808594 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(347.017578 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(408.541016 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(472.017578 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(503.804688 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(558.785156 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(619.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(683.345703 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(746.724609 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(785.933594 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_11">
+    <path d="M 371.87 244.024 
+L 371.87 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 616.8 244.024 
+L 616.8 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 371.87 244.024 
+L 616.8 244.024 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 371.87 26.88 
+L 616.8 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_34">
+    <!-- S0 -->
+    <g transform="translate(486.708438 20.88) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.476562 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_15">
+    <path d="M 680.27 244.024 
+L 925.2 244.024 
+L 925.2 26.88 
+L 680.27 26.88 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 691.403182 244.024 
+L 691.403182 243.426447 
+L 698.825303 243.426447 
+L 698.825303 243.224457 
+L 706.247424 243.224457 
+L 706.247424 242.879392 
+L 713.669545 242.879392 
+L 713.669545 242.610072 
+L 721.091667 242.610072 
+L 721.091667 241.692702 
+L 728.513788 241.692702 
+L 728.513788 241.347636 
+L 735.935909 241.347636 
+L 735.935909 240.001038 
+L 743.35803 240.001038 
+L 743.35803 238.982673 
+L 750.780152 238.982673 
+L 750.780152 236.802867 
+L 758.202273 236.802867 
+L 758.202273 234.370575 
+L 765.624394 234.370575 
+L 765.624394 229.539654 
+L 773.046515 229.539654 
+L 773.046515 221.106583 
+L 780.468636 221.106583 
+L 780.468636 205.620704 
+L 787.890758 205.620704 
+L 787.890758 170.777477 
+L 795.312879 170.777477 
+L 795.312879 96.167524 
+L 802.735 96.167524 
+L 802.735 37.22019 
+L 810.157121 37.22019 
+L 810.157121 112.48661 
+L 817.579242 112.48661 
+L 817.579242 179.454619 
+L 825.001364 179.454619 
+L 825.001364 208.978783 
+L 832.423485 208.978783 
+L 832.423485 222.596257 
+L 839.845606 222.596257 
+L 839.845606 230.726343 
+L 847.267727 230.726343 
+L 847.267727 234.40424 
+L 854.689848 234.40424 
+L 854.689848 237.509831 
+L 862.11197 237.509831 
+L 862.11197 238.334623 
+L 869.534091 238.334623 
+L 869.534091 239.992622 
+L 876.956212 239.992622 
+L 876.956212 240.901576 
+L 884.378333 240.901576 
+L 884.378333 241.372885 
+L 891.800455 241.372885 
+L 891.800455 241.886275 
+L 899.222576 241.886275 
+L 899.222576 242.138763 
+L 906.644697 242.138763 
+L 906.644697 242.618488 
+L 914.066818 242.618488 
+L 914.066818 244.024 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #555555; stroke-linejoin: miter"/>
+   </g>
+   <g id="PathCollection_10">
+    <g clip-path="url(#p31f86bdcaa)">
+     <use xlink:href="#m692a20c39d" x="693.778261" y="244.006172" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="701.200382" y="243.973228" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="708.622503" y="243.973013" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="716.044624" y="243.879537" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="723.466745" y="243.35667" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="730.888867" y="243.671603" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="738.310988" y="243.576768" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="745.733109" y="243.154397" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="753.15523" y="242.990009" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="760.577352" y="242.047106" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="767.999473" y="240.953005" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="775.421594" y="238.153353" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="782.843715" y="234.010855" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="790.265836" y="222.982919" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="797.687958" y="197.848092" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="805.110079" y="169.320703" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="812.5322" y="193.532457" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="819.954321" y="219.39425" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="827.376442" y="230.64784" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="834.798564" y="235.798794" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="842.220685" y="238.600549" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="849.642806" y="240.268265" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="857.064927" y="241.3907" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="864.487048" y="241.934688" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="871.90917" y="242.382096" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="879.331291" y="242.530235" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="886.753412" y="242.693229" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="894.175533" y="242.898491" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="901.597655" y="243.206167" style="stroke: #000000"/>
+     <use xlink:href="#m692a20c39d" x="909.019776" y="243.346226" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="PathCollection_11">
+    <g clip-path="url(#p31f86bdcaa)">
+     <use xlink:href="#m929e2037a8" x="695.114242" y="244.003841" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="702.536364" y="243.970569" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="709.958485" y="243.969863" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="717.380606" y="243.880493" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="724.802727" y="243.369929" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="732.224848" y="243.67646" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="739.64697" y="243.574147" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="747.069091" y="243.33069" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="754.491212" y="243.076361" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="761.913333" y="242.878939" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="769.335455" y="242.161583" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="776.757576" y="239.411182" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="784.179697" y="235.00521" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="791.601818" y="225.691169" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="799.023939" y="201.12241" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="806.446061" y="166.085994" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="813.868182" y="190.496665" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="821.290303" y="217.985708" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="828.712424" y="229.292735" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="836.134545" y="235.106867" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="843.556667" y="238.259925" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="850.978788" y="240.111424" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="858.400909" y="241.159375" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="865.82303" y="241.986682" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="873.245152" y="242.360681" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="880.667273" y="242.486148" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="888.089394" y="242.655635" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="895.511515" y="242.842973" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="902.933636" y="243.186215" style="fill: #0072b2; stroke: #0072b2"/>
+     <use xlink:href="#m929e2037a8" x="910.355758" y="243.327851" style="fill: #0072b2; stroke: #0072b2"/>
+    </g>
+   </g>
+   <g id="PathCollection_12">
+    <g clip-path="url(#p31f86bdcaa)">
+     <use xlink:href="#mf19d001b8d" x="696.450224" y="244.012251" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="703.872345" y="243.970789" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="711.294467" y="244.023863" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="718.716588" y="243.968634" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="726.138709" y="243.344694" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="733.56083" y="243.861361" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="740.982952" y="243.688246" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="748.405073" y="243.245024" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="755.827194" y="243.305218" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="763.249315" y="242.667659" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="770.671436" y="241.657786" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="778.093558" y="239.631229" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="785.515679" y="235.729213" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="792.9378" y="226.093082" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="800.359921" y="204.538946" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="807.782042" y="177.363383" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="815.204164" y="197.833826" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="822.626285" y="221.887434" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="830.048406" y="231.844056" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="837.470527" y="237.271474" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="844.892648" y="238.97509" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="852.31477" y="240.644861" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="859.736891" y="241.897959" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="867.159012" y="242.069202" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="874.581133" y="242.319974" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="882.003255" y="242.534345" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="889.425376" y="242.798349" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="896.847497" y="243.001369" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="904.269618" y="243.322514" style="fill: #d55e00; stroke: #d55e00"/>
+     <use xlink:href="#mf19d001b8d" x="911.691739" y="243.424733" style="fill: #d55e00; stroke: #d55e00"/>
+    </g>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_13">
+     <g id="line2d_50">
+      <path d="M 691.403182 244.024 
+L 691.403182 26.88 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="691.403182" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- 1.0 -->
+      <g transform="translate(683.451619 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_52">
+      <path d="M 735.935909 244.024 
+L 735.935909 26.88 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="735.935909" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- 1.2 -->
+      <g transform="translate(727.984347 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_54">
+      <path d="M 780.468636 244.024 
+L 780.468636 26.88 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="780.468636" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <!-- 1.4 -->
+      <g transform="translate(772.517074 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_56">
+      <path d="M 825.001364 244.024 
+L 825.001364 26.88 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="825.001364" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_38">
+      <!-- 1.6 -->
+      <g transform="translate(817.049801 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_58">
+      <path d="M 869.534091 244.024 
+L 869.534091 26.88 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="869.534091" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_39">
+      <!-- 1.8 -->
+      <g transform="translate(861.582528 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_60">
+      <path d="M 914.066818 244.024 
+L 914.066818 26.88 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#m42655b2cbf" x="914.066818" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_40">
+      <!-- 2.0 -->
+      <g transform="translate(906.115256 258.622437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_41">
+     <!-- $m(K_S K_S)$ [GeV] -->
+     <g transform="translate(766.785 272.300563) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(0 0.015625)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(97.412109 0.015625)"/>
+      <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(136.425781 0.015625)"/>
+      <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(202.001953 -16.390625) scale(0.7)"/>
+      <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(249.169922 0.015625)"/>
+      <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(314.746094 -16.390625) scale(0.7)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(361.914062 0.015625)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(400.927734 0.015625)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(432.714844 0.015625)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(471.728516 0.015625)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(549.21875 0.015625)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(610.742188 0.015625)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(679.150391 0.015625)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_13">
+     <g id="line2d_62">
+      <path d="M 680.27 244.024 
+L 925.2 244.024 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="680.27" y="244.024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_42">
+      <!-- 0 -->
+      <g transform="translate(666.9075 247.823219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_64">
+      <path d="M 680.27 201.942808 
+L 925.2 201.942808 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_65">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="680.27" y="201.942808" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_43">
+      <!-- 5000 -->
+      <g transform="translate(647.82 205.742027) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_66">
+      <path d="M 680.27 159.861616 
+L 925.2 159.861616 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_67">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="680.27" y="159.861616" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_44">
+      <!-- 10000 -->
+      <g transform="translate(641.4575 163.660835) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_68">
+      <path d="M 680.27 117.780424 
+L 925.2 117.780424 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_69">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="680.27" y="117.780424" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_45">
+      <!-- 15000 -->
+      <g transform="translate(641.4575 121.579643) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_70">
+      <path d="M 680.27 75.699232 
+L 925.2 75.699232 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_71">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="680.27" y="75.699232" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_46">
+      <!-- 20000 -->
+      <g transform="translate(641.4575 79.498451) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_72">
+      <path d="M 680.27 33.61804 
+L 925.2 33.61804 
+" clip-path="url(#p31f86bdcaa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_73">
+      <g>
+       <use xlink:href="#m4a9e6bd7f6" x="680.27" y="33.61804" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_47">
+      <!-- 25000 -->
+      <g transform="translate(641.4575 37.417259) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(254.492188 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_48">
+     <!-- projected counts -->
+     <g transform="translate(635.377813 177.354344) rotate(-90) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(102.339844 0)"/>
+      <use xlink:href="#DejaVuSans-6a" transform="translate(163.521484 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(191.304688 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(252.828125 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(307.808594 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(347.017578 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(408.541016 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(472.017578 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(503.804688 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(558.785156 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(619.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(683.345703 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(746.724609 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(785.933594 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_17">
+    <path d="M 680.27 244.024 
+L 680.27 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 925.2 244.024 
+L 925.2 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 680.27 244.024 
+L 925.2 244.024 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 680.27 26.88 
+L 925.2 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_49">
+    <!-- D2 -->
+    <g transform="translate(794.2975 20.88) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-44"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(77.001953 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p7076341611">
+   <rect x="63.47" y="26.88" width="244.93" height="217.144"/>
+  </clipPath>
+  <clipPath id="p399594f309">
+   <rect x="371.87" y="26.88" width="244.93" height="217.144"/>
+  </clipPath>
+  <clipPath id="p31f86bdcaa">
+   <rect x="680.27" y="26.88" width="244.93" height="217.144"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/py-laddu/laddu/__init__.py
+++ b/py-laddu/laddu/__init__.py
@@ -86,6 +86,9 @@ from .generation import (
     MandelstamTDistribution,
     ParticleSpecies,
     Reconstruction,
+    RejectionEnvelope,
+    RejectionSampleIter,
+    RejectionSamplingDiagnostics,
     StableGenerator,
 )
 from .likelihood import (
@@ -255,6 +258,9 @@ __all__ = [
     'Production',
     'Reaction',
     'Reconstruction',
+    'RejectionEnvelope',
+    'RejectionSampleIter',
+    'RejectionSamplingDiagnostics',
     'RuleSet',
     'Scalar',
     'SelectionRules',

--- a/py-laddu/laddu/__init__.py
+++ b/py-laddu/laddu/__init__.py
@@ -127,7 +127,7 @@ from .quantum import (
     allowed_projections,
     coupled_spins,
 )
-from .reaction import Decay, Particle, Reaction
+from .reaction import Decay, Particle, Production, Reaction
 from .variables import (
     Angles,
     CosTheta,
@@ -252,6 +252,7 @@ __all__ = [
     'PolPhase',
     'PolarComplexScalar',
     'Polarization',
+    'Production',
     'Reaction',
     'Reconstruction',
     'RuleSet',

--- a/py-laddu/laddu/__init__.pyi
+++ b/py-laddu/laddu/__init__.pyi
@@ -121,7 +121,7 @@ from .quantum import (
     allowed_projections,
     coupled_spins,
 )
-from .reaction import Decay, Particle, Reaction
+from .reaction import Decay, Particle, Production, Reaction
 from .variables import (
     Angles,
     CosTheta,
@@ -220,6 +220,7 @@ __all__ = [
     'PolPhase',
     'PolarComplexScalar',
     'Polarization',
+    'Production',
     'Reaction',
     'Reconstruction',
     'RuleSet',

--- a/py-laddu/laddu/__init__.pyi
+++ b/py-laddu/laddu/__init__.pyi
@@ -80,6 +80,9 @@ from .generation import (
     MandelstamTDistribution,
     ParticleSpecies,
     Reconstruction,
+    RejectionEnvelope,
+    RejectionSampleIter,
+    RejectionSamplingDiagnostics,
     StableGenerator,
 )
 from .likelihood import (
@@ -223,6 +226,9 @@ __all__ = [
     'Production',
     'Reaction',
     'Reconstruction',
+    'RejectionEnvelope',
+    'RejectionSampleIter',
+    'RejectionSamplingDiagnostics',
     'RuleSet',
     'Scalar',
     'SelectionRules',

--- a/py-laddu/laddu/_laddu.pyi
+++ b/py-laddu/laddu/_laddu.pyi
@@ -79,6 +79,9 @@ from laddu.generation import (
     MandelstamTDistribution,
     ParticleSpecies,
     Reconstruction,
+    RejectionEnvelope,
+    RejectionSampleIter,
+    RejectionSamplingDiagnostics,
     StableGenerator,
 )
 from laddu.likelihood import (
@@ -199,6 +202,7 @@ __all__ = [
     'Parameter',
     'ParameterMap',
     'Parity',
+    'ParquetBatchWriter',
     'ParquetChunkIter',
     'PartialWave',
     'Particle',
@@ -216,6 +220,9 @@ __all__ = [
     'Reaction',
     'Reconstruction',
     'Regularizer',
+    'RejectionEnvelope',
+    'RejectionSampleIter',
+    'RejectionSamplingDiagnostics',
     'RuleSet',
     'Scalar',
     'SelectionRules',
@@ -250,6 +257,7 @@ __all__ = [
     'is_root',
     'likelihood_product',
     'likelihood_sum',
+    'open_parquet_writer',
     'parameter',
     'read_parquet',
     'read_parquet_chunked',
@@ -347,6 +355,22 @@ def write_parquet(
     precision: Literal['f64', 'f32'] = 'f64',
 ) -> None:
     """Write a dataset to a Parquet file using the loaded backend."""
+
+class ParquetBatchWriter:
+    def write(self, dataset: Dataset) -> None: ...
+    def close(self) -> None: ...
+    def __enter__(self) -> ParquetBatchWriter: ...  # noqa: PYI034
+    def __exit__(
+        self, exc_type: object, exc_value: object, traceback: object
+    ) -> bool: ...
+
+def open_parquet_writer(
+    path: str | os.PathLike[str],
+    *,
+    chunk_size: int | None = None,
+    precision: Literal['f64', 'f32'] = 'f64',
+) -> ParquetBatchWriter:
+    """Open a streaming Parquet writer for compatible Dataset batches."""
 
 def write_root(
     dataset: Dataset,

--- a/py-laddu/laddu/_laddu.pyi
+++ b/py-laddu/laddu/_laddu.pyi
@@ -117,7 +117,7 @@ from laddu.quantum import (
     allowed_projections,
     coupled_spins,
 )
-from laddu.reaction import Decay, Particle, Reaction
+from laddu.reaction import Decay, Particle, Production, Reaction
 from laddu.variables import (
     Angles,
     CosTheta,
@@ -212,6 +212,7 @@ __all__ = [
     'PolPhase',
     'PolarComplexScalar',
     'Polarization',
+    'Production',
     'Reaction',
     'Reconstruction',
     'Regularizer',

--- a/py-laddu/laddu/generation.py
+++ b/py-laddu/laddu/generation.py
@@ -16,6 +16,9 @@ from laddu.laddu import (
     MandelstamTDistribution,
     ParticleSpecies,
     Reconstruction,
+    RejectionEnvelope,
+    RejectionSampleIter,
+    RejectionSamplingDiagnostics,
     StableGenerator,
 )
 
@@ -35,5 +38,8 @@ __all__ = [
     'MandelstamTDistribution',
     'ParticleSpecies',
     'Reconstruction',
+    'RejectionEnvelope',
+    'RejectionSampleIter',
+    'RejectionSamplingDiagnostics',
     'StableGenerator',
 ]

--- a/py-laddu/laddu/generation.pyi
+++ b/py-laddu/laddu/generation.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
 
+from laddu.amplitude import Expression
 from laddu.data import Dataset
 from laddu.math import Histogram
 from laddu.reaction import Reaction
@@ -144,6 +145,31 @@ class GeneratedBatchIter:
     def __iter__(self) -> GeneratedBatchIter: ...
     def __next__(self) -> GeneratedBatch: ...
 
+class RejectionEnvelope:
+    @staticmethod
+    def fixed(max_weight: float) -> RejectionEnvelope: ...
+    @staticmethod
+    def pilot(
+        pilot_events: int,
+        *,
+        safety_factor: float = 1.2,
+        batch_size: int | None = None,
+    ) -> RejectionEnvelope: ...
+
+class RejectionSamplingDiagnostics:
+    generated_events: int
+    accepted_events: int
+    rejected_events: int
+    max_observed_weight: float
+    envelope_max_weight: float
+    envelope_violations: int
+    def acceptance_efficiency(self) -> float: ...
+
+class RejectionSampleIter:
+    diagnostics: RejectionSamplingDiagnostics
+    def __iter__(self) -> RejectionSampleIter: ...
+    def __next__(self) -> GeneratedBatch: ...
+
 class EventGenerator:
     def __init__(
         self,
@@ -156,4 +182,26 @@ class EventGenerator:
     def generate_batches(
         self, total_events: int, batch_size: int
     ) -> GeneratedBatchIter: ...
+    def generate_batches_rejection(
+        self,
+        expression: Expression,
+        parameters: list[float] | tuple[float, ...],
+        *,
+        n_events: int,
+        generation_batch_size: int,
+        output_batch_size: int,
+        envelope: RejectionEnvelope,
+        seed: int | None = None,
+    ) -> RejectionSampleIter: ...
+    def generate_dataset_rejection(
+        self,
+        expression: Expression,
+        parameters: list[float] | tuple[float, ...],
+        *,
+        n_events: int,
+        generation_batch_size: int,
+        output_batch_size: int,
+        envelope: RejectionEnvelope,
+        seed: int | None = None,
+    ) -> Dataset: ...
     def generate_dataset(self, n_events: int) -> Dataset: ...

--- a/py-laddu/laddu/io.py
+++ b/py-laddu/laddu/io.py
@@ -32,8 +32,10 @@ _backend_from_columns = _backend_module.from_columns
 _backend_read_parquet = _backend_module.read_parquet
 _backend_read_parquet_chunked = _backend_module.read_parquet_chunked
 _backend_read_root = _backend_module.read_root
+_backend_open_parquet_writer = _backend_module.open_parquet_writer
 _backend_write_parquet = _backend_module.write_parquet
 _backend_write_root = _backend_module.write_root
+ParquetBatchWriter = _backend_module.ParquetBatchWriter
 
 if _TYPE_CHECKING:
     import pandas as pd
@@ -476,6 +478,20 @@ def write_parquet(
     validated_precision = _validate_precision(precision)
     _backend_write_parquet(
         dataset,
+        path,
+        chunk_size=chunk_size,
+        precision=validated_precision,
+    )
+
+
+def open_parquet_writer(
+    path: str | _Path,
+    *,
+    chunk_size: int = 10_000,
+    precision: _Literal['f64', 'f32'] = 'f64',
+) -> ParquetBatchWriter:
+    validated_precision = _validate_precision(precision)
+    return _backend_open_parquet_writer(
         path,
         chunk_size=chunk_size,
         precision=validated_precision,
@@ -1105,12 +1121,14 @@ def _amptools_columns(
 
 
 __all__ = [
+    'ParquetBatchWriter',
     'from_arrow',
     'from_columns',
     'from_dict',
     'from_numpy',
     'from_pandas',
     'from_polars',
+    'open_parquet_writer',
     'read_amptools',
     'read_amptools_chunked',
     'read_parquet',

--- a/py-laddu/laddu/io.pyi
+++ b/py-laddu/laddu/io.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
+from types import TracebackType
 from typing import Any, Literal, TypeAlias
 
 import numpy as np
@@ -115,6 +116,24 @@ def to_numpy(
     dataset: Dataset, *, precision: Literal['f64', 'f32'] = 'f64'
 ) -> dict[str, NDArray[np.floating]]: ...
 def to_arrow(dataset: Dataset, *, precision: Literal['f64', 'f32'] = 'f64') -> Any: ...
+
+class ParquetBatchWriter:
+    def write(self, dataset: Dataset) -> None: ...
+    def close(self) -> None: ...
+    def __enter__(self) -> ParquetBatchWriter: ...  # noqa: PYI034
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool: ...
+
+def open_parquet_writer(
+    path: str | Path,
+    *,
+    chunk_size: int = 10000,
+    precision: Literal['f64', 'f32'] = 'f64',
+) -> ParquetBatchWriter: ...
 def write_parquet(
     dataset: Dataset,
     path: str | Path,
@@ -134,12 +153,14 @@ def write_root(
 ) -> None: ...
 
 __all__ = [
+    'ParquetBatchWriter',
     'from_arrow',
     'from_columns',
     'from_dict',
     'from_numpy',
     'from_pandas',
     'from_polars',
+    'open_parquet_writer',
     'read_amptools',
     'read_amptools_chunked',
     'read_parquet',

--- a/py-laddu/laddu/reaction.py
+++ b/py-laddu/laddu/reaction.py
@@ -1,5 +1,5 @@
 """Reaction topology and decay-chain helpers."""
 
-from laddu.laddu import Decay, Particle, Reaction
+from laddu.laddu import Decay, Particle, Production, Reaction
 
-__all__ = ['Decay', 'Particle', 'Reaction']
+__all__ = ['Decay', 'Particle', 'Production', 'Reaction']

--- a/py-laddu/laddu/reaction.pyi
+++ b/py-laddu/laddu/reaction.pyi
@@ -80,6 +80,37 @@ class Decay:
         frame: _Frame = 'Helicity',
     ) -> Expression: ...
 
+class Production:
+    reaction: Reaction
+    produced: str
+    recoil: str
+
+    def costheta(self, frame: _Frame = 'Helicity') -> CosTheta: ...
+    def phi(self, frame: _Frame = 'Helicity') -> Phi: ...
+    def angles(self, frame: _Frame = 'Helicity') -> Angles: ...
+    def helicity_factor(
+        self,
+        *tags: str,
+        spin: QuantumNumber,
+        projection: QuantumNumber,
+        lambda_produced: QuantumNumber,
+        lambda_recoil: QuantumNumber,
+        frame: _Frame = 'Helicity',
+    ) -> Expression: ...
+    def canonical_factor(
+        self,
+        *tags: str,
+        spin: QuantumNumber,
+        projection: QuantumNumber,
+        orbital_l: QuantumNumber,
+        coupled_spin: QuantumNumber,
+        produced_spin: QuantumNumber,
+        recoil_spin: QuantumNumber,
+        lambda_produced: QuantumNumber,
+        lambda_recoil: QuantumNumber,
+        frame: _Frame = 'Helicity',
+    ) -> Expression: ...
+
 class Reaction:
     @staticmethod
     def two_to_two(
@@ -87,10 +118,11 @@ class Reaction:
     ) -> Reaction: ...
     def mass(self, particle: str) -> Mass: ...
     def decay(self, parent: str) -> Decay: ...
+    def production(self) -> Production: ...
     def mandelstam(
         self, channel: Literal['s', 't', 'u', 'S', 'T', 'U']
     ) -> Mandelstam: ...
     def pol_angle(self, pol_angle: str) -> PolAngle: ...
-    def polarization(self, pol_magnitude: str, pol_angle: str) -> Polarization: ...
+    def polarization(self, *, pol_magnitude: str, pol_angle: str) -> Polarization: ...
 
-__all__ = ['Decay', 'Particle', 'Reaction']
+__all__ = ['Decay', 'Particle', 'Production', 'Reaction']

--- a/py-laddu/pyproject.toml
+++ b/py-laddu/pyproject.toml
@@ -35,7 +35,7 @@ readme = "README.md"
 dependencies = [
   "laddu-cpu == 0.19.2", # x-release-please-version # WARNING: DO NOT EDIT
   "numpy",
-  "ganesh-rs == 0.27.0",
+  "ganesh-rs == 0.27.1",
 ]
 
 [project.urls]

--- a/py-laddu/tests/test_angular.py
+++ b/py-laddu/tests/test_angular.py
@@ -186,3 +186,65 @@ def test_decay_canonical_factor_matches_explicit_product() -> None:
 
     assert factor_value.real == pytest.approx(explicit_value.real)
     assert factor_value.imag == pytest.approx(explicit_value.imag)
+
+
+def test_production_helicity_factor_matches_explicit_wigner_d() -> None:
+    dataset = make_test_dataset()
+    rxn, _, _, _ = reaction()
+    production = rxn.production()
+    factor = production.helicity_factor(
+        'prod_h',
+        spin=1,
+        projection=1,
+        lambda_produced=0,
+        lambda_recoil=0,
+        frame='GottfriedJackson',
+    )
+    explicit = WignerD(
+        'prod_d',
+        spin=1,
+        row_projection=1,
+        column_projection=0,
+        angles=production.angles('GottfriedJackson'),
+    ).conj()
+
+    factor_value = factor.load(dataset).evaluate([])[0]
+    explicit_value = explicit.load(dataset).evaluate([])[0]
+
+    assert factor_value.real == pytest.approx(explicit_value.real)
+    assert factor_value.imag == pytest.approx(explicit_value.imag)
+
+
+def test_production_canonical_factor_matches_explicit_product() -> None:
+    dataset = make_test_dataset()
+    rxn, _, _, _ = reaction()
+    production = rxn.production()
+    factor = production.canonical_factor(
+        'prod_c',
+        spin=1,
+        projection=0,
+        orbital_l=1,
+        coupled_spin=1,
+        produced_spin=0,
+        recoil_spin=1,
+        lambda_produced=0,
+        lambda_recoil=0,
+        frame='GottfriedJackson',
+    )
+    explicit = (
+        ClebschGordan('prod_ls_cg', j1=1, m1=0, j2=1, m2=0, j=1, m=0)
+        * ClebschGordan('prod_spin_cg', j1=0, m1=0, j2=1, m2=0, j=1, m=0)
+        * WignerD(
+            'prod_d',
+            spin=1,
+            row_projection=0,
+            column_projection=0,
+            angles=production.angles('GottfriedJackson'),
+        ).conj()
+    )
+
+    factor_value = factor.load(dataset).evaluate([])[0]
+    explicit_value = explicit.load(dataset).evaluate([])[0] * (3.0**0.5)
+
+    assert factor_value.real == pytest.approx(explicit_value.real)
+    assert factor_value.imag == pytest.approx(explicit_value.imag)

--- a/py-laddu/tests/test_public_api.py
+++ b/py-laddu/tests/test_public_api.py
@@ -37,6 +37,24 @@ def test_decay_exposes_enclosing_reaction() -> None:
     assert isinstance(decay.reaction.mass('x'), ld.Mass)
 
 
+def test_production_exposes_two_to_two_roles() -> None:
+    beam = ld.Particle.stored('beam')
+    target = ld.Particle.missing('target')
+    daughter_1 = ld.Particle.stored('d1')
+    daughter_2 = ld.Particle.stored('d2')
+    x = ld.Particle.composite('x', (daughter_1, daughter_2))
+    recoil = ld.Particle.stored('recoil')
+    reaction = ld.Reaction.two_to_two(beam, target, x, recoil)
+
+    production = reaction.production()
+
+    assert isinstance(production.reaction, ld.Reaction)
+    assert production.produced == 'x'
+    assert production.recoil == 'recoil'
+    assert isinstance(production.angles(), ld.Angles)
+    assert 'Production' in repr(production)
+
+
 def test_reaction_rejects_invalid_particle_queries() -> None:
     beam = ld.Particle.stored('beam')
     target = ld.Particle.missing('target')
@@ -72,6 +90,7 @@ def test_domain_modules_export_expected_analysis_types() -> None:
     assert ld.reaction.Particle is ld.Particle
     assert ld.reaction.Reaction is ld.Reaction
     assert ld.reaction.Decay is ld.Decay
+    assert ld.reaction.Production is ld.Production
     assert ld.variables.Mass is ld.Mass
     assert ld.variables.CosTheta is ld.CosTheta
     assert ld.likelihood.NLL is ld.NLL


### PR DESCRIPTION
This PR does two things, it adds a `Production` object attached to `Reaction`s which plays a similar role to `Decay` but for the 2-to-2 production vertex. This enables us to make full physics models with a very formal amplitude definition!

The other addition is the ability to use `Expression`s to do rejection sampling on generated datasets. It also includes a pilot-envelope option with nice diagnostics.