### PR TITLE
UX Improvements

### DIFF
--- a/crates/laddu-amplitudes/src/angular/wigner.rs
+++ b/crates/laddu-amplitudes/src/angular/wigner.rs
@@ -159,7 +159,6 @@ pub trait ProductionAmplitudeExt {
         projection: Projection,
         lambda_produced: Projection,
         lambda_recoil: Projection,
-        frame: Frame,
     ) -> LadduResult<Expression>;
 
     /// Construct the canonical-basis spin-angular factor for one explicit LS/helicity term.
@@ -175,7 +174,6 @@ pub trait ProductionAmplitudeExt {
         recoil_spin: AngularMomentum,
         lambda_produced: Projection,
         lambda_recoil: Projection,
-        frame: Frame,
     ) -> LadduResult<Expression>;
 }
 
@@ -187,10 +185,9 @@ impl ProductionAmplitudeExt for Production {
         projection: Projection,
         lambda_produced: Projection,
         lambda_recoil: Projection,
-        frame: Frame,
     ) -> LadduResult<Expression> {
         let lambda = Projection::half_integer(lambda_produced.value() - lambda_recoil.value());
-        let angles = self.angles(frame)?;
+        let angles = self.angles()?;
         Ok(WignerD::new(tags, spin, projection, lambda, &angles)?.conj())
     }
 
@@ -205,7 +202,6 @@ impl ProductionAmplitudeExt for Production {
         recoil_spin: AngularMomentum,
         lambda_produced: Projection,
         lambda_recoil: Projection,
-        frame: Frame,
     ) -> LadduResult<Expression> {
         let lambda = Projection::half_integer(lambda_produced.value() - lambda_recoil.value());
         let minus_lambda_recoil = Projection::half_integer(-lambda_recoil.value());
@@ -229,14 +225,7 @@ impl ProductionAmplitudeExt for Production {
                     coupled_spin,
                     lambda,
                 )?
-                * self.helicity_factor(
-                    tags,
-                    spin,
-                    projection,
-                    lambda_produced,
-                    lambda_recoil,
-                    frame,
-                )?,
+                * self.helicity_factor(tags, spin, projection, lambda_produced, lambda_recoil)?,
         )
     }
 }

--- a/crates/laddu-core/src/kinematics/frame_axes.rs
+++ b/crates/laddu-core/src/kinematics/frame_axes.rs
@@ -63,12 +63,12 @@ impl FrameAxes {
         Self::new(x, y, z)
     }
 
-    /// Construct production-frame axes from caller-selected production momenta.
+    /// Construct decay-frame axes for a reaction root from caller-selected production momenta.
     ///
     /// `reference`, `parent`, and `spectator` are lab-frame four-momenta. `system_boost` is the
     /// boost into the frame where the production plane is defined. This keeps named event topology
     /// handling outside the frame helper while still sharing the convention-sensitive geometry.
-    pub fn from_production_frame(
+    pub fn from_decay_frame(
         frame: Frame,
         reference: Vec4,
         parent: Vec4,
@@ -90,7 +90,7 @@ impl FrameAxes {
         )?;
 
         let z = match frame {
-            Frame::Helicity => unit_vector(-spectator_in_parent, "production-frame z axis")?,
+            Frame::Helicity => unit_vector(-spectator_in_parent, "decay-frame z axis")?,
             Frame::GottfriedJackson => {
                 unit_vector(reference_in_parent, "Gottfried-Jackson z axis")?
             }
@@ -165,7 +165,7 @@ mod tests {
 
     fn transverse_axes(frame: Frame) -> FrameAxes {
         let (reference, parent, spectator) = transverse_momenta();
-        FrameAxes::from_production_frame(frame, reference, parent, spectator, Vec3::zero()).unwrap()
+        FrameAxes::from_decay_frame(frame, reference, parent, spectator, Vec3::zero()).unwrap()
     }
 
     fn assert_vec3_close(actual: Vec3, expected: Vec3) {
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn frame_axes_reject_degenerate_production_plane() {
-        let err = FrameAxes::from_production_frame(
+        let err = FrameAxes::from_decay_frame(
             Frame::Helicity,
             Vec4::new(0.0, 0.0, 5.0, 5.0),
             Vec4::new(0.0, 0.0, 1.0, 2.0),

--- a/crates/laddu-core/src/lib.rs
+++ b/crates/laddu-core/src/lib.rs
@@ -715,6 +715,12 @@ pub enum LadduError {
         /// Name that could not be resolved
         name: String,
     },
+    /// A particle is missing the requested property
+    #[error("Particle is missing the requested property \"{property}\"")]
+    MissingParticleProperty {
+        /// The name of the missing property
+        property: &'static str,
+    },
     /// A custom fallback error for errors too complex or too infrequent to warrant their own error
     /// category.
     #[error("{0}")]
@@ -771,6 +777,7 @@ impl From<LadduError> for PyErr {
             LadduError::ThreadPoolError(_) => PyRuntimeError::new_err(err_string),
             #[cfg(feature = "numpy")]
             LadduError::NumpyError(_) => PyValueError::new_err(err_string),
+            LadduError::MissingParticleProperty { .. } => PyValueError::new_err(err_string),
         }
     }
 }

--- a/crates/laddu-core/src/quantum/rules.rs
+++ b/crates/laddu-core/src/quantum/rules.rs
@@ -254,9 +254,9 @@ impl RuleSet {
         let i_parent = parent.isospin?;
         let i_a = daughters.0.isospin?;
         let i_b = daughters.1.isospin?;
-        let i3_parent = i_parent.projection()?;
-        let i3_a = i_a.projection()?;
-        let i3_b = i_b.projection()?;
+        let i3_parent = i_parent.projection?;
+        let i3_a = i_a.projection?;
+        let i3_b = i_b.projection?;
         Some(i3_parent.value() == i3_a.value() + i3_b.value())
     }
     fn check_c_parity(

--- a/crates/laddu-core/src/quantum/state.rs
+++ b/crates/laddu-core/src/quantum/state.rs
@@ -47,8 +47,10 @@ impl SpinState {
 /// An isospin state with optional projection.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Isospin {
-    isospin: AngularMomentum,
-    projection: Option<Projection>,
+    /// The total isospin of the state.
+    pub isospin: AngularMomentum,
+    /// The isospin projection of the state.
+    pub projection: Option<Projection>,
 }
 
 impl Isospin {
@@ -67,8 +69,13 @@ impl Isospin {
         self.isospin
     }
     /// The isospin projection of the state.
-    pub fn projection(self) -> Option<Projection> {
+    ///
+    /// Returns an error if this property is not known.
+    pub fn projection(self) -> LadduResult<Projection> {
         self.projection
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "isospin.projection",
+            })
     }
 }
 
@@ -116,6 +123,190 @@ pub struct ParticleProperties {
 }
 
 impl ParticleProperties {
+    /// Get the particle's name
+    ///
+    /// Returns an error if this property is not known.
+    pub fn name(&self) -> LadduResult<String> {
+        self.name
+            .clone()
+            .ok_or_else(|| LadduError::MissingParticleProperty { property: "name" })
+            .clone()
+    }
+    /// Get the particle's species
+    ///
+    /// Returns an error if this property is not known.
+    pub fn species(&self) -> LadduResult<String> {
+        self.species
+            .clone()
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "species",
+            })
+            .clone()
+    }
+    /// Get the particle's antiparticle species
+    ///
+    /// Returns an error if this property is not known.
+    pub fn antiparticle_species(&self) -> LadduResult<String> {
+        self.antiparticle_species
+            .clone()
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "antiparticle_species",
+            })
+            .clone()
+    }
+    /// Get the particle's self-conjugate status
+    ///
+    /// Returns an error if this property is not known.
+    pub fn self_conjugate(&self) -> LadduResult<bool> {
+        self.self_conjugate
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "self_conjugate",
+            })
+            .clone()
+    }
+    /// Get the particle's spin
+    ///
+    /// Returns an error if this property is not known.
+    pub fn spin(&self) -> LadduResult<AngularMomentum> {
+        self.spin
+            .ok_or_else(|| LadduError::MissingParticleProperty { property: "spin" })
+            .clone()
+    }
+    /// Get the particle's intrinsic parity
+    ///
+    /// Returns an error if this property is not known.
+    pub fn parity(&self) -> LadduResult<Parity> {
+        self.parity
+            .ok_or_else(|| LadduError::MissingParticleProperty { property: "parity" })
+            .clone()
+    }
+    /// Get the particle's intrinsic C-parity
+    ///
+    /// Returns an error if this property is not known.
+    pub fn c_parity(&self) -> LadduResult<Parity> {
+        self.c_parity
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "c_parity",
+            })
+            .clone()
+    }
+    /// Get the particle's intrinsic G-parity
+    ///
+    /// Returns an error if this property is not known.
+    pub fn g_parity(&self) -> LadduResult<Parity> {
+        self.g_parity
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "g_parity",
+            })
+            .clone()
+    }
+    /// Get the particle's electric charge
+    ///
+    /// Returns an error if this property is not known.
+    pub fn charge(&self) -> LadduResult<Charge> {
+        self.charge
+            .ok_or_else(|| LadduError::MissingParticleProperty { property: "charge" })
+            .clone()
+    }
+    /// Get the particle's isospin
+    ///
+    /// Returns an error if this property is not known.
+    pub fn isospin(&self) -> LadduResult<Isospin> {
+        self.isospin
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "isospin",
+            })
+            .clone()
+    }
+    /// Get the particle's strangeness
+    ///
+    /// Returns an error if this property is not known.
+    pub fn strangeness(&self) -> LadduResult<i32> {
+        self.strangeness
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "strangeness",
+            })
+            .clone()
+    }
+    /// Get the particle's charm
+    ///
+    /// Returns an error if this property is not known.
+    pub fn charm(&self) -> LadduResult<i32> {
+        self.charm
+            .ok_or_else(|| LadduError::MissingParticleProperty { property: "charm" })
+            .clone()
+    }
+    /// Get the particle's bottomness
+    ///
+    /// Returns an error if this property is not known.
+    pub fn bottomness(&self) -> LadduResult<i32> {
+        self.bottomness
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "bottomness",
+            })
+            .clone()
+    }
+    /// Get the particle's topness
+    ///
+    /// Returns an error if this property is not known.
+    pub fn topness(&self) -> LadduResult<i32> {
+        self.topness
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "topness",
+            })
+            .clone()
+    }
+    /// Get the particle's baryon number
+    ///
+    /// Returns an error if this property is not known.
+    pub fn baryon_number(&self) -> LadduResult<i32> {
+        self.baryon_number
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "baryon_number",
+            })
+            .clone()
+    }
+    /// Get the particle's electron lepton number
+    ///
+    /// Returns an error if this property is not known.
+    pub fn electron_lepton_number(&self) -> LadduResult<i32> {
+        self.electron_lepton_number
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "electron_lepton_number",
+            })
+            .clone()
+    }
+    /// Get the particle's muon lepton number
+    ///
+    /// Returns an error if this property is not known.
+    pub fn muon_lepton_number(&self) -> LadduResult<i32> {
+        self.muon_lepton_number
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "muon_lepton_number",
+            })
+            .clone()
+    }
+    /// Get the particle's tau lepton number
+    ///
+    /// Returns an error if this property is not known.
+    pub fn tau_lepton_number(&self) -> LadduResult<i32> {
+        self.tau_lepton_number
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "tau_lepton_number",
+            })
+            .clone()
+    }
+    /// Get the particle's statistics
+    ///
+    /// Returns an error if this property is not known.
+    pub fn statistics(&self) -> LadduResult<Statistics> {
+        self.statistics
+            .ok_or_else(|| LadduError::MissingParticleProperty {
+                property: "statistics",
+            })
+            .clone()
+    }
+
     /// Construct a particle with no specified properties.
     pub fn unknown() -> Self {
         Self::default()

--- a/crates/laddu-core/src/reaction/production.rs
+++ b/crates/laddu-core/src/reaction/production.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use super::Reaction;
 use crate::{
-    quantum::Frame,
     variables::{Angles, CosTheta, Phi},
     LadduResult,
 };
@@ -32,29 +31,26 @@ impl Production {
     }
 
     /// Return the production costheta variable.
-    pub fn costheta(&self, frame: Frame) -> LadduResult<CosTheta> {
+    pub fn costheta(&self) -> LadduResult<CosTheta> {
         Ok(CosTheta::from_production(
             self.reaction.clone(),
             self.produced.clone(),
-            frame,
         ))
     }
 
     /// Return the production phi variable.
-    pub fn phi(&self, frame: Frame) -> LadduResult<Phi> {
+    pub fn phi(&self) -> LadduResult<Phi> {
         Ok(Phi::from_production(
             self.reaction.clone(),
             self.produced.clone(),
-            frame,
         ))
     }
 
     /// Return both production angle variables.
-    pub fn angles(&self, frame: Frame) -> LadduResult<Angles> {
+    pub fn angles(&self) -> LadduResult<Angles> {
         Ok(Angles::from_production(
             self.reaction.clone(),
             self.produced.clone(),
-            frame,
         ))
     }
 }

--- a/crates/laddu-core/src/reaction/tests.rs
+++ b/crates/laddu-core/src/reaction/tests.rs
@@ -33,7 +33,7 @@ fn pion_cascade_dataset() -> (Dataset, Reaction, Particle, Particle, Particle) {
         Vec3::new(-0.200000000000000, 0.0, 0.400000000000000).with_mass(0.938000000000000);
     let beam_lab = Vec4::new(0.0, 0.0, 6.000000000000000, 6.000000000000000);
     let target_lab = x_lab + recoil_lab - beam_lab;
-    let x_rest_axes = FrameAxes::from_production_frame(
+    let x_rest_axes = FrameAxes::from_decay_frame(
         Frame::Helicity,
         beam_lab,
         x_lab,
@@ -337,7 +337,7 @@ fn reaction_mandelstam_variables_match_resolved_values() {
 }
 
 #[test]
-fn production_frame_axes_support_known_frames() {
+fn decay_root_axes_support_known_frames() {
     let (dataset, reaction, _, _, _) = pion_cascade_dataset();
     let event = dataset.event_local(0).unwrap();
 
@@ -357,21 +357,13 @@ fn reaction_production_view_infers_two_to_two_roles() {
 }
 
 #[test]
-fn production_angles_use_two_to_two_scattering_geometry() {
+fn production_angles_use_fixed_two_to_two_scattering_geometry() {
     let (dataset, reaction, _, _, _) = pion_cascade_dataset();
     let event = dataset.event_local(0).unwrap();
 
-    let helicity = reaction
-        .production_angles_value(&event, "x", Frame::Helicity)
-        .unwrap();
-    let gj = reaction
-        .production_angles_value(&event, "x", Frame::GottfriedJackson)
-        .unwrap();
+    let angles = reaction.production_angles_value(&event, "x").unwrap();
 
-    assert_relative_eq!(helicity.costheta(), 1.0);
-    assert!(gj.costheta() < 1.0);
-    assert!(gj.costheta() > -1.0);
-    assert!(reaction
-        .production_angles_value(&event, "rho", Frame::Helicity)
-        .is_err());
+    assert!(angles.costheta() < 1.0);
+    assert!(angles.costheta() > -1.0);
+    assert!(reaction.production_angles_value(&event, "rho").is_err());
 }

--- a/crates/laddu-core/src/reaction/topology.rs
+++ b/crates/laddu-core/src/reaction/topology.rs
@@ -183,7 +183,7 @@ impl Reaction {
                     ));
                 }
             };
-            return FrameAxes::from_production_frame(
+            return FrameAxes::from_decay_frame(
                 frame,
                 resolved.p1,
                 parent,
@@ -228,7 +228,6 @@ impl Reaction {
         &self,
         event: &dyn EventLike,
         produced: &str,
-        frame: Frame,
     ) -> LadduResult<DecayAngles> {
         let topology = self.two_to_two_topology()?;
         if produced != topology.p3() {
@@ -242,16 +241,7 @@ impl Reaction {
         let produced_p4 = resolved.p3.boost(&com_boost);
         let produced_vec = produced_p4.vec3();
         let plane_normal = reference.vec3().cross(&produced_vec);
-        let z = match frame {
-            Frame::Helicity => produced_vec,
-            Frame::GottfriedJackson => reference.vec3(),
-            Frame::Adair => {
-                return Err(LadduError::Custom(
-                    "Adair frame construction is not implemented yet".to_string(),
-                ));
-            }
-        };
-        FrameAxes::from_z_and_plane_normal(z, plane_normal)?.angles(produced_vec)
+        FrameAxes::from_z_and_plane_normal(reference.vec3(), plane_normal)?.angles(produced_vec)
     }
 
     /// Return the particle with the given identifier.

--- a/crates/laddu-core/src/variables/angles.rs
+++ b/crates/laddu-core/src/variables/angles.rs
@@ -16,6 +16,7 @@ enum AngleSource {
         reaction: Box<Reaction>,
         parent: String,
         daughter: String,
+        frame: Frame,
     },
     Production {
         reaction: Box<Reaction>,
@@ -29,59 +30,63 @@ impl AngleSource {
         Ok(())
     }
 
-    fn costheta(&self, event: &dyn EventLike, frame: Frame) -> f64 {
+    fn costheta(&self, event: &dyn EventLike) -> f64 {
         match self {
             Self::Decay {
                 reaction,
                 parent,
                 daughter,
+                frame,
             } => reaction
-                .angles_value(event, parent, daughter, frame)
+                .angles_value(event, parent, daughter, *frame)
                 .unwrap_or_else(|err| panic!("failed to evaluate reaction costheta: {err}"))
                 .costheta(),
             Self::Production { reaction, produced } => reaction
-                .production_angles_value(event, produced, frame)
+                .production_angles_value(event, produced)
                 .unwrap_or_else(|err| panic!("failed to evaluate production costheta: {err}"))
                 .costheta(),
         }
     }
 
-    fn phi(&self, event: &dyn EventLike, frame: Frame) -> f64 {
+    fn phi(&self, event: &dyn EventLike) -> f64 {
         match self {
             Self::Decay {
                 reaction,
                 parent,
                 daughter,
+                frame,
             } => reaction
-                .angles_value(event, parent, daughter, frame)
+                .angles_value(event, parent, daughter, *frame)
                 .unwrap_or_else(|err| panic!("failed to evaluate reaction phi: {err}"))
                 .phi(),
             Self::Production { reaction, produced } => reaction
-                .production_angles_value(event, produced, frame)
+                .production_angles_value(event, produced)
                 .unwrap_or_else(|err| panic!("failed to evaluate production phi: {err}"))
                 .phi(),
         }
     }
 
-    fn label(&self, kind: &str, frame: Frame) -> String {
+    fn label(&self, kind: &str) -> String {
         match self {
             Self::Decay {
-                parent, daughter, ..
+                parent,
+                daughter,
+                frame,
+                ..
             } => format!("{kind}(parent={parent}, daughter={daughter}, frame={frame})"),
-            Self::Production { produced, .. } => {
-                format!("{kind}(produced={produced}, frame={frame})")
-            }
+            Self::Production { produced, .. } => format!("{kind}(produced={produced})"),
         }
     }
 
-    fn angles_label(&self, frame: Frame) -> String {
+    fn angles_label(&self) -> String {
         match self {
             Self::Decay {
-                parent, daughter, ..
+                parent,
+                daughter,
+                frame,
+                ..
             } => format!("Angles(parent={parent}, daughter={daughter}, frame={frame})"),
-            Self::Production { produced, .. } => {
-                format!("Angles(produced={produced}, frame={frame})")
-            }
+            Self::Production { produced, .. } => format!("Angles(produced={produced})"),
         }
     }
 }
@@ -90,12 +95,11 @@ impl AngleSource {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CosTheta {
     source: AngleSource,
-    frame: Frame,
 }
 
 impl Display for CosTheta {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.source.label("CosTheta", self.frame))
+        write!(f, "{}", self.source.label("CosTheta"))
     }
 }
 
@@ -112,19 +116,18 @@ impl CosTheta {
                 reaction: Box::new(reaction),
                 parent: parent.into(),
                 daughter: daughter.into(),
+                frame,
             },
-            frame,
         }
     }
 
-    /// Construct an angle for the produced system in the production frame.
-    pub fn from_production(reaction: Reaction, produced: impl Into<String>, frame: Frame) -> Self {
+    /// Construct an angle for the produced system.
+    pub fn from_production(reaction: Reaction, produced: impl Into<String>) -> Self {
         Self {
             source: AngleSource::Production {
                 reaction: Box::new(reaction),
                 produced: produced.into(),
             },
-            frame,
         }
     }
 }
@@ -136,7 +139,7 @@ impl Variable for CosTheta {
     }
 
     fn value(&self, event: &dyn EventLike) -> f64 {
-        self.source.costheta(event, self.frame)
+        self.source.costheta(event)
     }
 }
 
@@ -144,12 +147,11 @@ impl Variable for CosTheta {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Phi {
     source: AngleSource,
-    frame: Frame,
 }
 
 impl Display for Phi {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.source.label("Phi", self.frame))
+        write!(f, "{}", self.source.label("Phi"))
     }
 }
 
@@ -166,19 +168,18 @@ impl Phi {
                 reaction: Box::new(reaction),
                 parent: parent.into(),
                 daughter: daughter.into(),
+                frame,
             },
-            frame,
         }
     }
 
-    /// Construct an angle for the produced system in the production frame.
-    pub fn from_production(reaction: Reaction, produced: impl Into<String>, frame: Frame) -> Self {
+    /// Construct an angle for the produced system.
+    pub fn from_production(reaction: Reaction, produced: impl Into<String>) -> Self {
         Self {
             source: AngleSource::Production {
                 reaction: Box::new(reaction),
                 produced: produced.into(),
             },
-            frame,
         }
     }
 }
@@ -190,7 +191,7 @@ impl Variable for Phi {
     }
 
     fn value(&self, event: &dyn EventLike) -> f64 {
-        self.source.phi(event, self.frame)
+        self.source.phi(event)
     }
 }
 
@@ -205,11 +206,7 @@ pub struct Angles {
 
 impl Display for Angles {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.costheta.source.angles_label(self.costheta.frame)
-        )
+        write!(f, "{}", self.costheta.source.angles_label())
     }
 }
 
@@ -240,10 +237,10 @@ impl Angles {
     }
 
     /// Construct reaction-derived production angle variables.
-    pub fn from_production(reaction: Reaction, produced: impl Into<String>, frame: Frame) -> Self {
+    pub fn from_production(reaction: Reaction, produced: impl Into<String>) -> Self {
         let produced = produced.into();
-        let costheta = CosTheta::from_production(reaction.clone(), produced.clone(), frame);
-        let phi = Phi::from_production(reaction, produced, frame);
+        let costheta = CosTheta::from_production(reaction.clone(), produced.clone());
+        let phi = Phi::from_production(reaction, produced);
         Self { costheta, phi }
     }
 }

--- a/crates/laddu-core/src/variables/tests.rs
+++ b/crates/laddu-core/src/variables/tests.rs
@@ -137,6 +137,16 @@ fn test_angles_display() {
 }
 
 #[test]
+fn test_production_angles_display() {
+    let (reaction, _, _, _) = reaction();
+    let angles = reaction.production().unwrap().angles().unwrap();
+
+    assert_eq!(angles.costheta.to_string(), "CosTheta(produced=kk)");
+    assert_eq!(angles.phi.to_string(), "Phi(produced=kk)");
+    assert_eq!(angles.to_string(), "Angles(produced=kk)");
+}
+
+#[test]
 fn test_pol_angle() {
     let dataset = test_dataset();
     let (reaction, _, _, _) = reaction();

--- a/crates/laddu-python/src/quantum.rs
+++ b/crates/laddu-python/src/quantum.rs
@@ -301,15 +301,20 @@ impl PyIsospin {
     }
 
     #[getter]
-    fn projection(&self, py: Python<'_>) -> PyResult<Option<PyQuantumNumber>> {
+    fn projection_unchecked(&self, py: Python<'_>) -> PyResult<Option<PyQuantumNumber>> {
         self.0
-            .projection()
+            .projection
             .map(|projection| projection_to_python(py, projection))
             .transpose()
     }
 
+    #[getter]
+    fn projection(&self, py: Python<'_>) -> PyResult<PyQuantumNumber> {
+        projection_to_python(py, self.0.projection()?)
+    }
+
     fn __repr__(&self) -> String {
-        match self.0.projection() {
+        match self.0.projection {
             Some(projection) => format!("Isospin({}, projection={})", self.0.isospin(), projection),
             None => format!("Isospin({})", self.0.isospin()),
         }
@@ -408,12 +413,52 @@ impl PyParticleProperties {
     }
 
     #[getter]
-    fn name(&self) -> Option<String> {
+    fn name(&self) -> PyResult<String> {
+        Ok(self.0.name()?)
+    }
+
+    #[getter]
+    fn name_unchecked(&self) -> Option<String> {
         self.0.name.clone()
     }
 
     #[getter]
-    fn spin(&self, py: Python<'_>) -> PyResult<Option<PyQuantumNumber>> {
+    fn species(&self) -> PyResult<String> {
+        Ok(self.0.species()?)
+    }
+
+    #[getter]
+    fn species_unchecked(&self) -> Option<String> {
+        self.0.species.clone()
+    }
+
+    #[getter]
+    fn antiparticle_species(&self) -> PyResult<String> {
+        Ok(self.0.antiparticle_species()?)
+    }
+
+    #[getter]
+    fn antiparticle_species_unchecked(&self) -> Option<String> {
+        self.0.antiparticle_species.clone()
+    }
+
+    #[getter]
+    fn self_conjugate(&self) -> PyResult<bool> {
+        Ok(self.0.self_conjugate()?)
+    }
+
+    #[getter]
+    fn self_conjugate_unchecked(&self) -> Option<bool> {
+        self.0.self_conjugate
+    }
+
+    #[getter]
+    fn spin(&self, py: Python<'_>) -> PyResult<PyQuantumNumber> {
+        angular_momentum_to_python(py, self.0.spin()?)
+    }
+
+    #[getter]
+    fn spin_unchecked(&self, py: Python<'_>) -> PyResult<Option<PyQuantumNumber>> {
         self.0
             .spin
             .map(|spin| angular_momentum_to_python(py, spin))
@@ -421,28 +466,143 @@ impl PyParticleProperties {
     }
 
     #[getter]
-    fn parity(&self) -> Option<PyParity> {
+    fn parity(&self) -> PyResult<PyParity> {
+        Ok(PyParity(self.0.parity()?))
+    }
+
+    #[getter]
+    fn parity_unchecked(&self) -> Option<PyParity> {
         self.0.parity.map(PyParity)
     }
 
     #[getter]
-    fn c_parity(&self) -> Option<PyParity> {
+    fn c_parity(&self) -> PyResult<PyParity> {
+        Ok(PyParity(self.0.c_parity()?))
+    }
+
+    #[getter]
+    fn c_parity_unchecked(&self) -> Option<PyParity> {
         self.0.c_parity.map(PyParity)
     }
 
     #[getter]
-    fn g_parity(&self) -> Option<PyParity> {
+    fn g_parity(&self) -> PyResult<PyParity> {
+        Ok(PyParity(self.0.g_parity()?))
+    }
+
+    #[getter]
+    fn g_parity_unchecked(&self) -> Option<PyParity> {
         self.0.g_parity.map(PyParity)
     }
 
     #[getter]
-    fn charge(&self) -> Option<PyCharge> {
+    fn charge(&self) -> PyResult<PyCharge> {
+        Ok(PyCharge(self.0.charge()?))
+    }
+
+    #[getter]
+    fn charge_unchecked(&self) -> Option<PyCharge> {
         self.0.charge.map(PyCharge)
     }
 
     #[getter]
-    fn isospin(&self) -> Option<PyIsospin> {
+    fn isospin(&self) -> PyResult<PyIsospin> {
+        Ok(PyIsospin(self.0.isospin()?))
+    }
+
+    #[getter]
+    fn isospin_unchecked(&self) -> Option<PyIsospin> {
         self.0.isospin.map(PyIsospin)
+    }
+
+    #[getter]
+    fn strangeness(&self) -> PyResult<i32> {
+        Ok(self.0.strangeness()?)
+    }
+
+    #[getter]
+    fn strangeness_unchecked(&self) -> Option<i32> {
+        self.0.strangeness
+    }
+
+    #[getter]
+    fn charm(&self) -> PyResult<i32> {
+        Ok(self.0.charm()?)
+    }
+
+    #[getter]
+    fn charm_unchecked(&self) -> Option<i32> {
+        self.0.charm
+    }
+
+    #[getter]
+    fn bottomness(&self) -> PyResult<i32> {
+        Ok(self.0.bottomness()?)
+    }
+
+    #[getter]
+    fn bottomness_unchecked(&self) -> Option<i32> {
+        self.0.bottomness
+    }
+
+    #[getter]
+    fn topness(&self) -> PyResult<i32> {
+        Ok(self.0.topness()?)
+    }
+
+    #[getter]
+    fn topness_unchecked(&self) -> Option<i32> {
+        self.0.topness
+    }
+
+    #[getter]
+    fn baryon_number(&self) -> PyResult<i32> {
+        Ok(self.0.baryon_number()?)
+    }
+
+    #[getter]
+    fn baryon_number_unchecked(&self) -> Option<i32> {
+        self.0.baryon_number
+    }
+
+    #[getter]
+    fn electron_lepton_number(&self) -> PyResult<i32> {
+        Ok(self.0.electron_lepton_number()?)
+    }
+
+    #[getter]
+    fn electron_lepton_number_unchecked(&self) -> Option<i32> {
+        self.0.electron_lepton_number
+    }
+
+    #[getter]
+    fn muon_lepton_number(&self) -> PyResult<i32> {
+        Ok(self.0.muon_lepton_number()?)
+    }
+
+    #[getter]
+    fn muon_lepton_number_unchecked(&self) -> Option<i32> {
+        self.0.muon_lepton_number
+    }
+
+    #[getter]
+    fn tau_lepton_number(&self) -> PyResult<i32> {
+        Ok(self.0.tau_lepton_number()?)
+    }
+
+    #[getter]
+    fn tau_lepton_number_unchecked(&self) -> Option<i32> {
+        self.0.tau_lepton_number
+    }
+
+    #[getter]
+    fn statistics(&self) -> PyResult<PyStatistics> {
+        Ok(self.0.statistics()?.into())
+    }
+
+    #[getter]
+    fn statistics_unchecked(&self) -> Option<PyStatistics> {
+        self.0.statistics.map(|s| s.into())
     }
 
     fn __repr__(&self) -> String {

--- a/crates/laddu-python/src/variables.rs
+++ b/crates/laddu-python/src/variables.rs
@@ -416,26 +416,23 @@ impl PyProduction {
         self.0.recoil().to_string()
     }
 
-    /// Production costheta variable for the selected frame.
-    #[pyo3(signature=(frame="Helicity"))]
-    fn costheta(&self, frame: &str) -> PyResult<PyCosTheta> {
-        Ok(PyCosTheta(self.0.costheta(frame.parse()?)?))
+    /// Production costheta variable.
+    fn costheta(&self) -> PyResult<PyCosTheta> {
+        Ok(PyCosTheta(self.0.costheta()?))
     }
 
-    /// Production phi variable for the selected frame.
-    #[pyo3(signature=(frame="Helicity"))]
-    fn phi(&self, frame: &str) -> PyResult<PyPhi> {
-        Ok(PyPhi(self.0.phi(frame.parse()?)?))
+    /// Production phi variable.
+    fn phi(&self) -> PyResult<PyPhi> {
+        Ok(PyPhi(self.0.phi()?))
     }
 
-    /// Production angle variables for the selected frame.
-    #[pyo3(signature=(frame="Helicity"))]
-    fn angles(&self, frame: &str) -> PyResult<PyAngles> {
-        Ok(PyAngles(self.0.angles(frame.parse()?)?))
+    /// Production angle variables.
+    fn angles(&self) -> PyResult<PyAngles> {
+        Ok(PyAngles(self.0.angles()?))
     }
 
     /// Construct the helicity-basis production angular factor for one explicit helicity term.
-    #[pyo3(signature=(*tags, spin, projection, lambda_produced, lambda_recoil, frame="Helicity"))]
+    #[pyo3(signature=(*tags, spin, projection, lambda_produced, lambda_recoil))]
     #[allow(clippy::too_many_arguments)]
     fn helicity_factor(
         &self,
@@ -444,7 +441,6 @@ impl PyProduction {
         projection: &Bound<'_, PyAny>,
         lambda_produced: &Bound<'_, PyAny>,
         lambda_recoil: &Bound<'_, PyAny>,
-        frame: &str,
     ) -> PyResult<PyExpression> {
         Ok(PyExpression(self.0.helicity_factor(
             py_tags(tags)?,
@@ -452,12 +448,11 @@ impl PyProduction {
             parse_projection(projection)?,
             parse_projection(lambda_produced)?,
             parse_projection(lambda_recoil)?,
-            frame.parse()?,
         )?))
     }
 
     /// Construct the canonical-basis production spin-angular factor for one LS/helicity term.
-    #[pyo3(signature=(*tags, spin, projection, orbital_l, coupled_spin, produced_spin, recoil_spin, lambda_produced, lambda_recoil, frame="Helicity"))]
+    #[pyo3(signature=(*tags, spin, projection, orbital_l, coupled_spin, produced_spin, recoil_spin, lambda_produced, lambda_recoil))]
     #[allow(clippy::too_many_arguments)]
     fn canonical_factor(
         &self,
@@ -470,7 +465,6 @@ impl PyProduction {
         recoil_spin: &Bound<'_, PyAny>,
         lambda_produced: &Bound<'_, PyAny>,
         lambda_recoil: &Bound<'_, PyAny>,
-        frame: &str,
     ) -> PyResult<PyExpression> {
         Ok(PyExpression(self.0.canonical_factor(
             py_tags(tags)?,
@@ -482,7 +476,6 @@ impl PyProduction {
             parse_angular_momentum(recoil_spin)?,
             parse_projection(lambda_produced)?,
             parse_projection(lambda_recoil)?,
-            frame.parse()?,
         )?))
     }
 

--- a/py-laddu/examples/example_production_vertex/example_production_vertex.py
+++ b/py-laddu/examples/example_production_vertex/example_production_vertex.py
@@ -97,7 +97,7 @@ def allowed_production_waves(
     max_l: int,
 ) -> list[ld.PartialWave]:
     waves = []
-    for j_initial in ld.coupled_spins(PHOTON.spin, PROTON.spin):  # ty: ignore
+    for j_initial in ld.coupled_spins(PHOTON.spin, PROTON.spin):
         parent = ld.ParticleProperties(f'gamma_p_J{j_initial}', spin=j_initial)
         allowed_waves = ld.allowed_partial_waves(
             parent,
@@ -117,8 +117,8 @@ def decay_factor(decay_wave: DecayWave) -> ld.Expression:
         orbital_l=decay_wave.l,
         coupled_spin=0,
         daughter='kshort1',
-        daughter_1_spin=KSHORT.spin,  # ty: ignore
-        daughter_2_spin=KSHORT.spin,  # ty: ignore
+        daughter_1_spin=KSHORT.spin,
+        daughter_2_spin=KSHORT.spin,
         lambda_1=0,
         lambda_2=0,
         frame=FRAME,
@@ -142,10 +142,9 @@ def production_factor(
         orbital_l=production_wave.l,
         coupled_spin=production_wave.s,
         produced_spin=decay_wave.j,
-        recoil_spin=PROTON.spin,  # ty: ignore
+        recoil_spin=PROTON.spin,
         lambda_produced=decay_wave.m,
         lambda_recoil=recoil_spin,
-        frame=FRAME,
     )
 
 

--- a/py-laddu/laddu/quantum.pyi
+++ b/py-laddu/laddu/quantum.pyi
@@ -31,19 +31,51 @@ class Charge:
 
 class Isospin:
     isospin: int | Fraction
-    projection: int | Fraction | None
+    projection: int | Fraction
+    projection_unchecked: int | Fraction | None
     def __init__(
         self, isospin: QuantumNumber, *, projection: QuantumNumber | None = None
     ) -> None: ...
 
 class ParticleProperties:
-    name: str | None
-    spin: int | Fraction | None
-    parity: Parity | None
-    c_parity: Parity | None
-    g_parity: Parity | None
-    charge: Charge | None
-    isospin: Isospin | None
+    name: str
+    name_unchecked: str | None
+    species: str
+    species_unchecked: str | None
+    antiparticle_species: str
+    antiparticle_species_unchecked: str | None
+    self_conjugate: bool
+    self_conjugate_unchecked: bool | None
+    spin: int | Fraction
+    spin_unchecked: int | Fraction | None
+    parity: Parity
+    parity_unchecked: Parity | None
+    c_parity: Parity
+    c_parity_unchecked: Parity | None
+    g_parity: Parity
+    g_parity_unchecked: Parity | None
+    charge: Charge
+    charge_unchecked: Charge | None
+    isospin: Isospin
+    isospin_unchecked: Isospin | None
+    strangeness: int
+    strangeness_unchecked: int | None
+    charm: int
+    charm_unchecked: int | None
+    bottomness: int
+    bottomness_unchecked: int | None
+    topness: int
+    topness_unchecked: int | None
+    baryon_number: int
+    baryon_number_unchecked: int | None
+    electron_lepton_number: int
+    electron_lepton_number_unchecked: int | None
+    muon_lepton_number: int
+    muon_lepton_number_unchecked: int | None
+    tau_lepton_number: int
+    tau_lepton_number_unchecked: int | None
+    statistics: Statistics
+    statistics_unchecked: Statistics | None
     def __init__(
         self,
         name: str | None = None,

--- a/py-laddu/laddu/reaction.pyi
+++ b/py-laddu/laddu/reaction.pyi
@@ -85,9 +85,9 @@ class Production:
     produced: str
     recoil: str
 
-    def costheta(self, frame: _Frame = 'Helicity') -> CosTheta: ...
-    def phi(self, frame: _Frame = 'Helicity') -> Phi: ...
-    def angles(self, frame: _Frame = 'Helicity') -> Angles: ...
+    def costheta(self) -> CosTheta: ...
+    def phi(self) -> Phi: ...
+    def angles(self) -> Angles: ...
     def helicity_factor(
         self,
         *tags: str,
@@ -95,7 +95,6 @@ class Production:
         projection: QuantumNumber,
         lambda_produced: QuantumNumber,
         lambda_recoil: QuantumNumber,
-        frame: _Frame = 'Helicity',
     ) -> Expression: ...
     def canonical_factor(
         self,
@@ -108,7 +107,6 @@ class Production:
         recoil_spin: QuantumNumber,
         lambda_produced: QuantumNumber,
         lambda_recoil: QuantumNumber,
-        frame: _Frame = 'Helicity',
     ) -> Expression: ...
 
 class Reaction:

--- a/py-laddu/tests/test_angular.py
+++ b/py-laddu/tests/test_angular.py
@@ -198,14 +198,13 @@ def test_production_helicity_factor_matches_explicit_wigner_d() -> None:
         projection=1,
         lambda_produced=0,
         lambda_recoil=0,
-        frame='GottfriedJackson',
     )
     explicit = WignerD(
         'prod_d',
         spin=1,
         row_projection=1,
         column_projection=0,
-        angles=production.angles('GottfriedJackson'),
+        angles=production.angles(),
     ).conj()
 
     factor_value = factor.load(dataset).evaluate([])[0]
@@ -229,7 +228,6 @@ def test_production_canonical_factor_matches_explicit_product() -> None:
         recoil_spin=1,
         lambda_produced=0,
         lambda_recoil=0,
-        frame='GottfriedJackson',
     )
     explicit = (
         ClebschGordan('prod_ls_cg', j1=1, m1=0, j2=1, m2=0, j=1, m=0)
@@ -239,7 +237,7 @@ def test_production_canonical_factor_matches_explicit_product() -> None:
             spin=1,
             row_projection=0,
             column_projection=0,
-            angles=production.angles('GottfriedJackson'),
+            angles=production.angles(),
         ).conj()
     )
 

--- a/py-laddu/tests/test_quantum.py
+++ b/py-laddu/tests/test_quantum.py
@@ -43,7 +43,7 @@ def test_particle_properties_accept_keyword_quantum_numbers() -> None:
     assert pi_plus.name == 'pi+'
     assert pi_plus.spin == 0
     assert str(pi_plus.parity) == '-'
-    assert pi_plus.charge is not None
+    assert pi_plus.charge_unchecked is not None
     assert pi_plus.charge.value == 1
 
 


### PR DESCRIPTION
- Removed "frame" argument from production (the "helicity" frame was misguided and trivial)
- Added unchecked/checked accessors for particle properties
  - This makes it easier to use them as inputs where they're expected to be not `None`